### PR TITLE
Better forceios/forcedroid actions

### DIFF
--- a/shared/commandLineUtils.js
+++ b/shared/commandLineUtils.js
@@ -142,14 +142,17 @@ var processArgument = function(argValue, argsMap, argProcessor, postProcessingCa
             console.log(outputColors.red + 'Invalid value for \'' + argProcessor.argName + '\'.' + outputColors.reset);
         }
     }
-    var rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-    rl.question(argProcessor.inputPrompt + ' ', function(answer) {
-        rl.close();
-        processArgument(answer, argsMap, argProcessor, postProcessingCallback);
-    });
+    // If we have an inputPrompt, prompt the user
+    if (argProcessor.inputPrompt) {
+        var rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+        rl.question(argProcessor.inputPrompt + ' ', function(answer) {
+            rl.close();
+            processArgument(answer, argsMap, argProcessor, postProcessingCallback);
+        });
+    }
 };
 
 /**
@@ -165,7 +168,7 @@ var ArgProcessorList = function() {
  * Adds an ArgProcessor to the list of processors.
  *
  * @param {String} argName The name of the argument.
- * @param {String} inputPrompt The prompt to show the user, when interactively configuring the arg value.
+ * @param {String} inputPrompt The prompt to show the user, when interactively configuring the arg value. If null, the user will not be prompted interactively.
  * @param {Function} processorFunction The function used to validate the arg value.
  * @param {Function} preprocessorFunction An optional function that can be used to determine whether the argument should be configured.
  * @return {ArgProcessorList} The updated ArgProcessorList, for chaining calls.
@@ -181,16 +184,13 @@ ArgProcessorList.prototype.addArgProcessor = function(argName, inputPrompt, proc
  *
  * @constructor
  * @param {String} argName The name of the argument.
- * @param {String} inputPrompt The prompt to show the user, when interactively configuring the arg value.
+ * @param {String} inputPrompt The prompt to show the user, when interactively configuring the arg value. If null, the user will not be prompted interactively.
  * @param {Function} processorFunction The function used to validate the arg value.
  * @param {Function} preprocessorFunction An optional function that can be used to determine whether the argument should be configured.
  */
 var ArgProcessor = function(argName, inputPrompt, processorFunction, preprocessorFunction) {
     if ((typeof argName !== 'string') || argName.trim() === '') {
         throw new Error('Invalid value for argName: \'' + argName + '\'.');
-    }
-    if ((typeof inputPrompt !== 'string') || (inputPrompt.trim() === '')) {
-        throw new Error('Invalid value for inputPrompt: \'' + inputPrompt + '\'.');
     }
     if (typeof processorFunction !== 'function') {
         throw new Error('processorFunction should be a function.');

--- a/shared/commandLineUtils.js
+++ b/shared/commandLineUtils.js
@@ -153,6 +153,9 @@ var processArgument = function(argValue, argsMap, argProcessor, postProcessingCa
             processArgument(answer, argsMap, argProcessor, postProcessingCallback);
         });
     }
+    else {
+        processArgument('', argsMap, argProcessor, postProcessingCallback);
+    }
 };
 
 /**

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -62,16 +62,15 @@ function usage(toolName, toolVersion, appTypes) {
     log('    --appname=<Application Name>', COLOR.magenta);
     log('    --packagename=<App Package Identifier> (e.g. com.mycompany.myapp)', COLOR.magenta);
     log('    --organization=<Organization Name> (Your company\'s/organization\'s name)', COLOR.magenta);
+    log('    --outputdir=<Output directory> (Leave empty for current directory)]', COLOR.magenta);
     log('    --startpage=<App Start Page> (The start page of your remote app. Only required for hybrid_remote)', COLOR.magenta);
-    log('    --outputdir=<Output directory> (Leave empty for current directory.)]', COLOR.magenta);
     log('\n OR \n', COLOR.cyan);
     log(toolName + ' createWithTemplate', COLOR.magenta);
     log('    --templaterepourl=<Template repo URL> (e.g. https://github.com/forcedotcom/SmartSyncExplorerReactNative)]', COLOR.magenta);
     log('    --appname=<Application Name>', COLOR.magenta);
     log('    --packagename=<App Package Identifier> (e.g. com.mycompany.myapp)', COLOR.magenta);
     log('    --organization=<Organization Name> (Your company\'s/organization\'s name)', COLOR.magenta);
-    log('    --startpage=<App Start Page> (The start page of your remote app. Only required for hybrid_remote)', COLOR.magenta);
-    log('    --outputdir=<Output directory> (Leave empty for current directory.)]', COLOR.magenta);
+    log('    --outputdir=<Output directory> (Leave empty for current directory)]', COLOR.magenta);
     log('\n OR \n', COLOR.cyan);
     log(toolName + ' version', COLOR.magenta);
 }
@@ -118,13 +117,11 @@ function createArgsProcessorList(appTypes, isCreateWithTemplate) {
 
     // Template Path - private param (not documented in usage, user is never prompted)
     addProcessorFor(argProcessorList, 'templatepath', null,
-                    'Invalid value for template path: \'$val\'.', /.*/, 
-                    function(argsMap) { return (argsMap['templaterepourl'] && argsMap['templaterepourl'].indexOf('SalesforceMobileSDK-Templates') == -1); });
+                    'Invalid value for template path: \'$val\'.', /.*/);
 
     // Plugin URL - private param (not documented in usage, user is never prompted)
     addProcessorFor(argProcessorList, 'pluginrepourl', null,
-                    'Invalid value for plugin repo url: \'$val\'.', /.*/, 
-                    function(argsMap) { return (argsMap['apptype'].indexOf('hybrid') >= 0); });
+                    'Invalid value for plugin repo url: \'$val\'.', /.*/);
     
     return argProcessorList;
 }

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -44,7 +44,7 @@ function readConfig(args, toolName, toolVersion, appTypes, handler) {
     case 'create': 
         processorList = createArgsProcessorList(appTypes); 
         break;
-    case 'createWithConfig': 
+    case 'createWithTemplate': 
         processorList = createArgsProcessorList(appTypes, true); 
         break;
     default:
@@ -63,13 +63,15 @@ function usage(toolName, toolVersion, appTypes) {
     log('    --packagename=<App Package Identifier> (e.g. com.mycompany.myapp)', COLOR.magenta);
     log('    --organization=<Organization Name> (Your company\'s/organization\'s name)', COLOR.magenta);
     log('    --startpage=<App Start Page> (The start page of your remote app. Only required for hybrid_remote)', COLOR.magenta);
-    log('\n OR \n', COLOR.cyan);
-    log(toolName + ' createWithConfig', COLOR.magenta);
-    log('   Same arguments as create plus the following:', COLOR.magenta);
     log('    --outputdir=<Output directory> (Leave empty for current directory.)]', COLOR.magenta);
-    log('    --templaterepourl=<Template repo URL> (Leave empty for default template repo.)]', COLOR.magenta);
-    log('    --templatepath=<Path> (Path of template application in template repo. Optional.)]', COLOR.magenta);
-    log('    --pluginrepourl=<Cordova plugin URL> (Leave empty for version ' + toolVersion + ' of mobile sdk plugin.)]', COLOR.magenta);
+    log('\n OR \n', COLOR.cyan);
+    log(toolName + ' createWithTemplate', COLOR.magenta);
+    log('    --templaterepourl=<Template repo URL> (e.g. https://github.com/forcedotcom/SmartSyncExplorerReactNative)]', COLOR.magenta);
+    log('    --appname=<Application Name>', COLOR.magenta);
+    log('    --packagename=<App Package Identifier> (e.g. com.mycompany.myapp)', COLOR.magenta);
+    log('    --organization=<Organization Name> (Your company\'s/organization\'s name)', COLOR.magenta);
+    log('    --startpage=<App Start Page> (The start page of your remote app. Only required for hybrid_remote)', COLOR.magenta);
+    log('    --outputdir=<Output directory> (Leave empty for current directory.)]', COLOR.magenta);
     log('\n OR \n', COLOR.cyan);
     log(toolName + ' version', COLOR.magenta);
 }
@@ -77,13 +79,20 @@ function usage(toolName, toolVersion, appTypes) {
 //
 // Processor list for 'create' command
 //
-function createArgsProcessorList(appTypes, presentExtraArgs) {
+function createArgsProcessorList(appTypes, isCreateWithTemplate) {
     var argProcessorList = new commandLineUtils.ArgProcessorList();
 
-    // App type
-    addProcessorFor(argProcessorList, 'apptype', 'Enter your application type (' + appTypes.join(', ') + '):',
-                    'App type must be ' + appTypes.join(', ') + '.', 
-                    function(val) { return appTypes.indexOf(val) >= 0; });
+    if (isCreateWithTemplate) {
+        // Template Repo URL
+        addProcessorFor(argProcessorList, 'templaterepourl', 'Enter URL of repo containing template application (leave empty for default template):',
+                     'Invalid value for template repo url: \'$val\'.', /.*/);
+    }
+    else {
+        // App type
+        addProcessorFor(argProcessorList, 'apptype', 'Enter your application type (' + appTypes.join(', ') + '):',
+                        'App type must be ' + appTypes.join(', ') + '.', 
+                        function(val) { return appTypes.indexOf(val) >= 0; });
+    }
 
     // App name
     addProcessorFor(argProcessorList, 'appname', 'Enter your application name:',
@@ -102,28 +111,21 @@ function createArgsProcessorList(appTypes, presentExtraArgs) {
                     'Invalid value for start page: \'$val\'.', /\S+/, 
                     function(argsMap) { return (argsMap['apptype'] === 'hybrid_remote'); });
 
-    if (presentExtraArgs) {
-        // Output dir
-        addProcessorFor(argProcessorList, 'outputdir', 'Enter the output directory for your app (leave empty for the current directory):',
-                     'Invalid value for output directory: \'$val\'.', /.*/); 
-
-        // Template Repo URL
-        addProcessorFor(argProcessorList, 'templaterepourl', 'Enter URL of repo containing template application (leave empty for default template):',
-                     'Invalid value for template repo url: \'$val\'.', /.*/);
+    // Output dir
+    addProcessorFor(argProcessorList, 'outputdir', 'Enter the output directory for your app (leave empty for the current directory):',
+                    'Invalid value for output directory: \'$val\'.', /.*/); 
 
 
-        // Template Path
-        addProcessorFor(argProcessorList, 'templatepath', 'Enter path of template application in template repo:',
-                        'Invalid value for template path: \'$val\'.', /.*/, 
-                        function(argsMap) { return (argsMap['templaterepourl'] && argsMap['templaterepourl'].indexOf('SalesforceMobileSDK-Templates') == -1); });
+    // Template Path - private param (not documented in usage, user is never prompted)
+    addProcessorFor(argProcessorList, 'templatepath', null,
+                    'Invalid value for template path: \'$val\'.', /.*/, 
+                    function(argsMap) { return (argsMap['templaterepourl'] && argsMap['templaterepourl'].indexOf('SalesforceMobileSDK-Templates') == -1); });
 
-        // Plugin URL
-        addProcessorFor(argProcessorList, 'pluginrepourl', 'Enter the URL or path of mobile sdk cordova plugin (leave empty for latest plugin):',
-                        'Invalid value for plugin repo url: \'$val\'.', /.*/, 
-                        function(argsMap) { return (argsMap['apptype'].indexOf('hybrid') >= 0); });
-    }
-
-
+    // Plugin URL - private param (not documented in usage, user is never prompted)
+    addProcessorFor(argProcessorList, 'pluginrepourl', null,
+                    'Invalid value for plugin repo url: \'$val\'.', /.*/, 
+                    function(argsMap) { return (argsMap['apptype'].indexOf('hybrid') >= 0); });
+    
     return argProcessorList;
 }
 

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -83,8 +83,8 @@ function createArgsProcessorList(appTypes, isCreateWithTemplate) {
 
     if (isCreateWithTemplate) {
         // Template Repo URL
-        addProcessorFor(argProcessorList, 'templaterepourl', 'Enter URL of repo containing template application (leave empty for default template):',
-                     'Invalid value for template repo url: \'$val\'.', /.*/);
+        addProcessorFor(argProcessorList, 'templaterepourl', 'Enter URL of repo containing template application:',
+                     'Invalid value for template repo url: \'$val\'.', /^\S+$/);
     }
     else {
         // App type

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -134,20 +134,24 @@ function printDetails(config) {
                         '',
                         '  in:                   ' + config.projectPath,
                         '',
-                        '  from template repo:   ' + config.templaterepourl,
-                        '       template path:   ' + config.templatepath
+                        '  from template repo:   ' + config.templaterepourl
                   ];
+
+    if (config.templatepath) {
+        details = details.concat(['       template path:   ' + config.templatepath]);
+    }
+            
 
     // Hybrid extra details
     if (config.apptype.indexOf('hybrid') >= 0) {
+        if (config.apptype === 'hybrid_remote') {
+            details = details.concat(['       start page:      ' + config.startpage]);
+        }
+
         details = details.concat([
             '       cordova version: ' + config.cordovaPlatformVersion,
             '       plugin repo:     ' + config.cordovaPluginRepoUrl
         ]);
-
-        if (config.apptype === 'hybrid_remote') {
-            details = details.concat(['       start page:      ' + config.startpage]);
-        }
     }
             
     utils.logParagraph(details);

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -157,7 +157,7 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
     var outputDir = path.join(tmpDir, appName);
     var forcePath = path.join(tmpDir, 'node_modules', '.bin', FORCE_CLI[os]);
 
-    var forceArgs = 'createWithConfig '
+    var forceArgs = 'createWithTemplate '
         + ' --apptype=' + appType
         + ' --appname=' + appName
         + ' --packagename=com.mycompany'
@@ -165,7 +165,6 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
         + ' --outputdir=' + outputDir
         + (isNative ? '' : ' --startpage=/apex/testPage')
         + ' --templaterepourl=' + templateRepoUrl
-        + ' --templatepath' 
         + ' --pluginrepourl=' + pluginRepoUrl
 
     // Generation

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -108,8 +108,8 @@ function usage() {
     utils.log('  test_force.js', COLOR.magenta);
     utils.log('    --os=os1,os2,etc', COLOR.magenta);
     utils.log('    --apptype=appType1,appType2,etc', COLOR.magenta);
-    utils.log('    [--templaterepourl=TEMPLATE_REPO_URL (Defaults to https://github.com/forcedotcom/SalesforceMobileSDK-Templates#unstable)]', COLOR.magenta);
-    utils.log('    [--pluginrepourl=PLUGIN_REPO_URL (Defaults to https://github.com/forcedotcom/SalesforceMobileSDK-Templates#unstable)]', COLOR.magenta);
+    utils.log('    [--templaterepourl=TEMPLATE_REPO_URL (Defaults to url in shared/constants.js)]', COLOR.magenta);
+    utils.log('    [--pluginrepourl=PLUGIN_REPO_URL (Defaults to url in shared/constants.js)]', COLOR.magenta);
     utils.log('    [--sdkbranch=SDK_BRANCH (Defaults to unstable)]', COLOR.magenta);
     utils.log('  Where:', COLOR.cyan);
     utils.log('  - osX is : ios or android', COLOR.cyan);
@@ -152,6 +152,7 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
     if (appType === APP_TYPE.native_swift && os === OS.android) return; // that app type doesn't exist for android
 
     var isNative = appType.indexOf('native') >= 0;
+    var isHybridRemote = appType === APP_TYPE.hybrid_remote;
     var target = appType + ' app for ' + os;
     var appName = appType + os + 'App';
     var outputDir = path.join(tmpDir, appName);
@@ -163,7 +164,7 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
         + ' --packagename=com.mycompany'
         + ' --organization=MyCompany'
         + ' --outputdir=' + outputDir
-        + (isNative ? '' : ' --startpage=/apex/testPage')
+        + (isHybridRemote ? '' : ' --startpage=/apex/testPage')
         + ' --templaterepourl=' + templateRepoUrl
         + ' --pluginrepourl=' + pluginRepoUrl
 

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -49,23 +49,26 @@ function main(args) {
     // Args extraction
     var usageRequested = parsedArgs.hasOwnProperty('usage');
     var chosenOperatingSystems = cleanSplit(parsedArgs.os, ',');
-    var templateRepoUrl = parsedArgs.templaterepourl || defaultTemplateRepoUrl;
-    var pluginRepoUrl = parsedArgs.pluginrepourl || defaultPluginRepoUrl;
+    var appTypes = parsedArgs.apptype || '';
+    var templateRepoUrl = parsedArgs.templaterepourl || '';
+    var pluginRepoUrl = parsedArgs.pluginrepourl;
     var sdkBranch = parsedArgs.sdkbranch || defaultSdkBranch;
-    
     var chosenAppTypes = cleanSplit(parsedArgs.apptype, ',');
+
+    
+    var testingWithAppType = chosenAppTypes.length > 0;
+    var testingWithTemplate = templateRepoUrl != '';
     var testingIOS = chosenOperatingSystems.indexOf(OS.ios) >= 0;
     var testingAndroid = chosenOperatingSystems.indexOf(OS.android) >= 0;
     var testingHybrid = chosenAppTypes.indexOf(APP_TYPE.hybrid_local) >= 0 || chosenAppTypes.indexOf(APP_TYPE.hybrid_remote) >= 0;
 
     // Validation
     validateOperatingSystems(chosenOperatingSystems);
-    validateAppTypes(chosenAppTypes);
+    validateAppTypesTemplateRepoUrl(chosenAppTypes, templateRepoUrl);
 
     // Usage
-    if (usageRequested || (!testingIOS && !testingAndroid) || chosenAppTypes.length === 0) {
-        usage();
-        process.exit(1);
+    if (usageRequested) {
+        usage(0);
     }
 
     // Actual testing
@@ -91,9 +94,14 @@ function main(args) {
     // Test all the platforms / app types requested
     for (var i=0; i<chosenOperatingSystems.length; i++) {
         var os = chosenOperatingSystems[i];
-        for (var j=0; j<chosenAppTypes.length; j++) {
-            var appType = chosenAppTypes[j];
-            createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl);
+        if (testingWithAppType) {
+            for (var j=0; j<chosenAppTypes.length; j++) {
+                var appType = chosenAppTypes[j];
+                createCompileApp(tmpDir, os, appType, null, pluginRepoUrl);
+            }
+        }
+        if (testingWithTemplate) {
+            createCompileApp(tmpDir, os, null, templateRepoUrl, null);
         }
     }
 }
@@ -101,19 +109,20 @@ function main(args) {
 //
 // Usage
 //
-function usage() {
-    utils.log('Usage:',  COLOR.cyan);
+function usage(exitCode) {
+    utils.log('Usage:\n',  COLOR.cyan);
     utils.log('  test_force.js --usage', COLOR.magenta);
-    utils.log('OR ', COLOR.cyan);
+    utils.log('\n OR \n', COLOR.cyan);
     utils.log('  test_force.js', COLOR.magenta);
     utils.log('    --os=os1,os2,etc', COLOR.magenta);
-    utils.log('    --apptype=appType1,appType2,etc', COLOR.magenta);
-    utils.log('    [--templaterepourl=TEMPLATE_REPO_URL (Defaults to url in shared/constants.js)]', COLOR.magenta);
+    utils.log('    --apptype=appType1,appType2,etc OR --templaterepourl=TEMPLATE_REPO_URL', COLOR.magenta);
     utils.log('    [--pluginrepourl=PLUGIN_REPO_URL (Defaults to url in shared/constants.js)]', COLOR.magenta);
     utils.log('    [--sdkbranch=SDK_BRANCH (Defaults to unstable)]', COLOR.magenta);
+    utils.log('', COLOR.cyan);
     utils.log('  Where:', COLOR.cyan);
     utils.log('  - osX is : ios or android', COLOR.cyan);
     utils.log('  - appTypeX is: native, native_swift, react_native, hybrid_local or hybrid_remote', COLOR.cyan);
+    utils.log('  - templaterepourl is a template repo url e.g. https://github.com/forcedotcom/SmartSyncExplorerReactNative#unstable', COLOR.cyan);
     utils.log('', COLOR.cyan);
     utils.log('  If hybrid is targeted, the following are first done:', COLOR.cyan);
     utils.log('  - clones PLUGIN_REPO_URL ', COLOR.cyan);
@@ -126,6 +135,8 @@ function usage() {
     utils.log('  If android is targeted:', COLOR.cyan);
     utils.log('  - generates forcedroid package and deploys it to a temporary directory', COLOR.cyan);
     utils.log('  - creates and compile the application types using specified template and plugin', COLOR.cyan);
+
+    process.exit(exitCode);
 }
 
 //
@@ -149,24 +160,33 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
 // Create and compile app 
 //
 function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
-    if (appType === APP_TYPE.native_swift && os === OS.android) return; // that app type doesn't exist for android
-
-    var isNative = appType.indexOf('native') >= 0;
-    var isHybridRemote = appType === APP_TYPE.hybrid_remote;
-    var target = appType + ' app for ' + os;
-    var appName = appType + os + 'App';
+    var forceArgs = '';
+    var actualAppType = appType || getAppTypeFromTemplate(templateRepoUrl)
+    var isNative = actualAppType.indexOf('native') >= 0;
+    var isHybridRemote = actualAppType === APP_TYPE.hybrid_remote;
+    var target = actualAppType + ' app for ' + os + (templateRepoUrl ? ' based on template ' + getTemplateNameFromUrl(templateRepoUrl) : '');
+    var appName = actualAppType + os + 'App';
     var outputDir = path.join(tmpDir, appName);
     var forcePath = path.join(tmpDir, 'node_modules', '.bin', FORCE_CLI[os]);
 
-    var forceArgs = 'createWithTemplate '
-        + ' --apptype=' + appType
+    if (appType != null) {
+        if (appType === APP_TYPE.native_swift && os === OS.android) return; // that app type doesn't exist for android
+
+        forceArgs = 'create '
+            + ' --apptype=' + appType;
+    }
+    else {
+        forceArgs = 'createWithTemplate '
+            + ' --templaterepourl=' + templateRepoUrl;
+    }
+
+    forceArgs += ''
         + ' --appname=' + appName
         + ' --packagename=com.mycompany'
         + ' --organization=MyCompany'
         + ' --outputdir=' + outputDir
-        + (isHybridRemote ? '' : ' --startpage=/apex/testPage')
-        + ' --templaterepourl=' + templateRepoUrl
-        + ' --pluginrepourl=' + pluginRepoUrl
+        + (isHybridRemote ? ' --startpage=/apex/testPage' : '')
+        + (isNative ? '' : ' --pluginrepourl=' + pluginRepoUrl);
 
     // Generation
     var generationSucceeded = utils.runProcessCatchError(forcePath + ' ' + forceArgs, 'GENERATING ' + target);
@@ -176,7 +196,8 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
     }
 
     // App dir
-    var appDir = appType === APP_TYPE.react_native ? path.join(outputDir, os) : outputDir;
+
+    var appDir = actualAppType === APP_TYPE.react_native ? path.join(outputDir, os) : outputDir;
 
     // Compilation
     if (isNative) {
@@ -184,13 +205,13 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
             // IOS - Native
             var workspacePath = path.join(appDir, appName + '.xcworkspace');
             utils.runProcessCatchError('xcodebuild -workspace ' + workspacePath 
-                                 + ' -scheme ' + appName
-                                 + ' clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO', 
-                                 'COMPILING ' + target); 
+                                       + ' -scheme ' + appName
+                                       + ' clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO', 
+                                       'COMPILING ' + target); 
         }
         else {
             // Android - Native
-            var appDir = appType === APP_TYPE.react_native ? path.join(outputDir, os) : outputDir;
+            var appDir = actualAppType === APP_TYPE.react_native ? path.join(outputDir, os) : outputDir;
             var gradle = isWindows() ? '.\\gradlew.bat' : './gradlew';
             utils.runProcessCatchError(gradle + ' assembleDebug', 'COMPILING ' + target, appDir);
         }
@@ -212,24 +233,35 @@ function createCompileApp(tmpDir, os, appType, templateRepoUrl, pluginRepoUrl) {
 // Helper to validate operating systems
 //
 function validateOperatingSystems(chosenOperatingSystems) {
+    if (chosenOperatingSystems.length == 0) {
+        utils.log('You need to specify at least one os\n', COLOR.red);
+        usage(1);
+    }
     for (var i=0; i<chosenOperatingSystems.length; i++) {
         var os = chosenOperatingSystems[i];
         if (!OS.hasOwnProperty(os) || (isWindows() && os === OS.ios)) {
-            log('Invalid os: ' + os, COLOR.red);
-            process.exit(1);
+            utils.log('Invalid os: ' + os + '\n', COLOR.red);
+            usage(1);
         }
     }
 }
 
 // 
-// Helper to validate app types
+// Helper to validate app types / template repo url
 //
-function validateAppTypes(chosenAppTypes) {
+function validateAppTypesTemplateRepoUrl(chosenAppTypes, templateRepoUrl) {
+    console.log("--> " + chosenAppTypes.length == 0);
+    console.log("--> " + templateRepoUrl === '');
+    if (!(chosenAppTypes.length == 0 ^ templateRepoUrl === '')) {
+        utils.log('You need to specify apptype or templaterepourl (but not both)\n', COLOR.red);
+        usage(1);
+    }
+    
     for (var i=0; i<chosenAppTypes.length; i++) {
         var appType = chosenAppTypes[i];
         if (!APP_TYPE.hasOwnProperty(appType)) {
-            utils.log('Invalid appType: ' + appType, COLOR.red);
-            process.exit(1);
+            utils.log('Invalid appType: ' + appType + '\n', COLOR.red);
+            usage(1);
         }
     }
 }
@@ -255,3 +287,32 @@ function cleanSplit(str, delimiter) {
 function isWindows() {
     return /^win/.test(process.platform);
 }
+
+//
+// Get template name from url
+//
+function getTemplateNameFromUrl(templateRepoUrl) {
+    var parts = templateRepoUrl.split('/');
+    return parts[parts.length-1];
+}
+
+
+//
+// Get template apptype
+//
+function getAppTypeFromTemplate(templateRepoUrl) {
+    // Creating tmp dir for template clone
+    var tmpDir = utils.mkTmpDir();
+
+    // Cloning template repo
+    var repoDir = utils.cloneRepo(tmpDir, templateRepoUrl);
+
+    // Getting template
+    var appType = require(path.join(repoDir, 'template.js')).appType;
+    
+    // Cleanup
+    utils.removeFile(tmpDir);
+
+    // Done
+    return appType;
+}    


### PR DESCRIPTION
Instead of create and createWithConfig, we now have create and createWithTemplate.
* create expects an apptype (along with appname, packagename, organization, and optionally outputdir)
* createWithTemplate instead expects a templaterepourl (also with appname, packagename, organization, and optionally outputdir)

That way it should be close to what it was before for users that do not care about templates.

That was made possible by having templates know their own app type (see https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/7)

Finally the pluginrepourl (to use another plugin repo) and templatepath (to allow a template repo to host multiple templates) are now "hidden" arguments (they are not shown by usage and are never prompted to the user - they will however be used if passed on the command line (test_force.js makes use of them).