### PR TITLE
If you are testing hybrid apps for iOS and android, we should not run…

### DIFF
--- a/test/test_force.js
+++ b/test/test_force.js
@@ -87,8 +87,9 @@ function main(args) {
         if (pluginRepoUri.indexOf('//') >= 0) {
             // Actual uri - clone repo - run tools/update.sh
             var pluginRepoDir = utils.cloneRepo(tmpDir, pluginRepoUri);
-            if (testingIOS) updatePluginRepo(tmpDir, OS.ios, pluginRepoDir, sdkBranch);
-            if (testingAndroid) updatePluginRepo(tmpDir, OS.android, pluginRepoDir, sdkBranch);
+            if (testingIOS && testingAndroid) updatePluginRepo(tmpDir, 'all', pluginRepoDir, sdkBranch);
+            if (testingIOS && !testingAndroid) updatePluginRepo(tmpDir, OS.ios, pluginRepoDir, sdkBranch);
+            if (testingAndroid && !testingIOS) updatePluginRepo(tmpDir, OS.android, pluginRepoDir, sdkBranch);
             // Use local updated clone of plugin
             pluginRepoUri = pluginRepoDir;
         }


### PR DESCRIPTION
… update plugin repo twice

it's inefficient
more importantly, the cleanup of the second run will wipe out the first platform which will break cordova platform add in the generated app