### PR TITLE
2.13 is required for some of our git commands (used to get sdk faster…

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -31,7 +31,7 @@ module.exports = {
     version: VERSION,
 
     tools: {
-        gitMinVersion: '2.10',
+        gitMinVersion: '2.13',
         npmMinVersion: '3.10',
         podMinVersion: '1.2'
     },


### PR DESCRIPTION
… when generating apps)