### PR TITLE
Exposing command's description in longDescription field

### DIFF
--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -65,6 +65,7 @@ function getCommandExpanded(cli, commandName) {
         name: command.name,
         args: getArgsExpanded(cli, commandName),
         description: applyCli(command.description, cli),
+        longDescription: applyCli(command.description, cli),
         help: applyCli(command.help, cli)
     };
 }


### PR DESCRIPTION
* The longDescription values are used only in the reference doc. 
* The description values are used only on the command line. 
* The help values are used in both places (and, on the command line, the -h | --help output also includes some info in addition to the help property's value). 

So, for commands, description and longDescription should basically contain the same information, and should not duplicate what's in help (which is the appropriate place for usage notes and examples). 

For parameters, it's ok to put extra info that you want to include in the reference doc in longDescription but not in description, but just keep in mind that that info will be visible only in the reference doc.