### PR TITLE
Adding longDescriptions back in for inclusion in Reference

### DIFF
--- a/sfdx/index.js
+++ b/sfdx/index.js
@@ -88,6 +88,7 @@ function getCommands() {
                 topic: cli.topic,
                 command: commandName,
                 description: command.description,
+                longDescription: command.longDescription,
                 help: command.help,
                 flags: command.args,
                 run(context) {

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -65,7 +65,7 @@ function getCommandExpanded(cli, commandName) {
         name: command.name,
         args: getArgsExpanded(cli, commandName),
         description: applyCli(command.description, cli),
-        longDescription: applyCli(command.description, cli),
+        longDescription: applyCli(command.longDescription, cli),
         help: applyCli(command.help, cli)
     };
 }

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -231,6 +231,7 @@ module.exports = {
                           cli.name === 'forcehybrid' ? 'pluginRepoUri' : null
                          ].filter(x=>x!=null),
             description: cli => 'create ' + cli.purpose,
+            longDescription: cli => 'Create ' + cli.purpose + '.',
             help: 'This command initiates creation of a new app based on the standard Mobile SDK template.'
         },
         createwithtemplate: {
@@ -244,12 +245,14 @@ module.exports = {
                           'verbose'
                          ].filter(x=>x!=null),
             description: cli => 'create ' + cli.purpose + ' from a template',
+            longDescription: cli => 'Create ' + cli.purpose + ' from a template.',
             help: 'This command initiates creation of a new app based on the Mobile SDK template that you specify. The template can be a specialized app for your app type that Mobile SDK provides, or your own custom app that you\'ve configured to use as a template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_new_project_template.htm for information on custom templates.'
         },
         version: {
             name: 'version',
             args: [],
-            description: 'print version of Mobile SDK',
+            description: 'show version of Mobile SDK',
+            longDescription: 'Show version of Mobile SDK.',
             help: 'This command displays to the console the version of Mobile SDK that the script uses to create apps.'
         }
     }


### PR DESCRIPTION
Added longDescriptions to the commands and doctored the code to read them. The longDescriptions added are exactly the same as the descriptions, but they are styled for the upcoming Reference.