### PR TITLE
Removing Mac OS Requirement for forcehybrid and forcereact

### DIFF
--- a/hybrid/package.json
+++ b/hybrid/package.json
@@ -8,7 +8,6 @@
 	"licenses" : [
 	    { "type": "Salesforce.com Mobile SDK License", "url": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/master/LICENSE.md" }
 	],
-	"os" : [ "darwin" ],
 	"bin" : { "forcehybrid" : "forcehybrid.js" },
     "dependencies": {
         "shelljs": "~0.7.0"

--- a/hybrid/package.json
+++ b/hybrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forcehybrid",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"description": "Utilities for creating hybrid mobile apps based on the Salesforce Mobile SDK for iOS and Android",
 	"keywords": [ "mobilesdk", "ios", "android", "hybrid", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-Package",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forcereact",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"description": "Utilities for creating react native mobile apps based on the Salesforce Mobile SDK for iOS and Android",
 	"keywords": [ "mobilesdk", "ios", "android", "react", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-Package",

--- a/react/package.json
+++ b/react/package.json
@@ -8,7 +8,6 @@
 	"licenses" : [
 	    { "type": "Salesforce.com Mobile SDK License", "url": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/master/LICENSE.md" }
 	],
-	"os" : [ "darwin" ],
 	"bin" : { "forcereact" : "forcereact.js" },
     "dependencies": {
         "shelljs": "~0.7.0"


### PR DESCRIPTION
This PR bumps up only the package version because that's all we need to publish a new package. There are no code changes elsewhere, so the tags remain the same (`v6.0.0`).