### PR TITLE
Fixes node 8 issue

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -48,8 +48,8 @@ module.exports = {
         },
         cordova: {
             checkCmd: 'cordova -v',
-            minVersion: '7.0.0',
             pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#dev',    // dev
+            minVersion: '8.0.0',
             //pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#v' + VERSION, // GA
             platformVersion: {
                 ios: '4.5.4',


### PR DESCRIPTION
Currently the min version required for the cordova cli is 7.0.0.
If you use that version, then you must use node 6. It throws an error with node 8.
However if you use cordova cli 8.0.0, then it works with node 6 and node 8.
=> In Mobile SDK 6.2, we should require cordova cli 8 so that they can use any versions of node they want.