### PR TITLE
New action for force clis: listtemplates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+sfdx/yarn.lock

--- a/android/README.md
+++ b/android/README.md
@@ -52,6 +52,11 @@ forcedroid createwithtemplate
 
  OR 
 
+# list available Mobile SDK templates
+forcedroid listtemplates
+
+ OR 
+
 # show version of Mobile SDK
 forcedroid version
 

--- a/hybrid/README.md
+++ b/hybrid/README.md
@@ -55,6 +55,11 @@ forcehybrid createwithtemplate
 
  OR 
 
+# list available Mobile SDK templates
+forcehybrid listtemplates
+
+ OR 
+
 # show version of Mobile SDK
 forcehybrid version
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -52,6 +52,11 @@ forceios createwithtemplate
 
  OR 
 
+# list available Mobile SDK templates
+forceios listtemplates
+
+ OR 
+
 # show version of Mobile SDK
 forceios version
 

--- a/react/README.md
+++ b/react/README.md
@@ -53,6 +53,11 @@ forcereact createwithtemplate
 
  OR 
 
+# list available Mobile SDK templates
+forcereact listtemplates
+
+ OR 
+
 # show version of Mobile SDK
 forcereact version
 

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -44,6 +44,7 @@ sfdx mobilesdk:ios commands: (get help with sfdx help mobilesdk:ios:COMMAND)
  mobilesdk:ios:create              create an iOS native mobile application
  mobilesdk:ios:createwithtemplate  create an iOS native mobile application from
                                    a template
+ mobilesdk:ios:listtemplates       list available Mobile SDK templates
  mobilesdk:ios:version             show version of Mobile SDK
 
 ```
@@ -57,14 +58,10 @@ create an iOS native mobile application
 
 Flags:
  -n, --appname APPNAME            (required) application name
- -t, --apptype APPTYPE            (required) application type (native,
-                                  native_swift)
- -o, --organization ORGANIZATION  (required) organization name (your
-                                  company's/organization's name)
- -d, --outputdir OUTPUTDIR        output directory (leave empty for current
-                                  directory)
- -k, --packagename PACKAGENAME    (required) app package identifier (e.g.
-                                  com.mycompany.myapp)
+ -t, --apptype APPTYPE            (required) application type (native, native_swift)
+ -o, --organization ORGANIZATION  (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR        output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME    (required) app package identifier (e.g. com.mycompany.myapp)
 
 This command initiates creation of a new app based on the standard Mobile SDK template.
 
@@ -79,12 +76,9 @@ create an iOS native mobile application from a template
 
 Flags:
  -n, --appname APPNAME                  (required) application name
- -o, --organization ORGANIZATION        (required) organization name (your
-                                        company's/organization's name)
- -d, --outputdir OUTPUTDIR              output directory (leave empty for
-                                        current directory)
- -k, --packagename PACKAGENAME          (required) app package identifier (e.g.
-                                        com.mycompany.myapp)
+ -o, --organization ORGANIZATION        (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR              output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME          (required) app package identifier (e.g. com.mycompany.myapp)
  -r, --templaterepouri TEMPLATEREPOURI  (required) template repo URI
 
 This command initiates creation of a new app based on the Mobile SDK template that you specify. The template can be a specialized app for your app type that Mobile SDK provides, or your own custom app that you've configured to use as a template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_new_project_template.htm for information on custom templates.
@@ -100,6 +94,7 @@ sfdx mobilesdk:android commands: (get help with sfdx help mobilesdk:android:COMM
                                        application
  mobilesdk:android:createwithtemplate  create an Android native mobile
                                        application from a template
+ mobilesdk:android:listtemplates       list available Mobile SDK templates
  mobilesdk:android:version             show version of Mobile SDK
 
 ```
@@ -113,14 +108,10 @@ create an Android native mobile application
 
 Flags:
  -n, --appname APPNAME            (required) application name
- -t, --apptype APPTYPE            (required) application type (native,
-                                  native_kotlin)
- -o, --organization ORGANIZATION  (required) organization name (your
-                                  company's/organization's name)
- -d, --outputdir OUTPUTDIR        output directory (leave empty for current
-                                  directory)
- -k, --packagename PACKAGENAME    (required) app package identifier (e.g.
-                                  com.mycompany.myapp)
+ -t, --apptype APPTYPE            (required) application type (native, native_kotlin)
+ -o, --organization ORGANIZATION  (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR        output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME    (required) app package identifier (e.g. com.mycompany.myapp)
 
 This command initiates creation of a new app based on the standard Mobile SDK template.
 
@@ -135,12 +126,9 @@ create an Android native mobile application from a template
 
 Flags:
  -n, --appname APPNAME                  (required) application name
- -o, --organization ORGANIZATION        (required) organization name (your
-                                        company's/organization's name)
- -d, --outputdir OUTPUTDIR              output directory (leave empty for
-                                        current directory)
- -k, --packagename PACKAGENAME          (required) app package identifier (e.g.
-                                        com.mycompany.myapp)
+ -o, --organization ORGANIZATION        (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR              output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME          (required) app package identifier (e.g. com.mycompany.myapp)
  -r, --templaterepouri TEMPLATEREPOURI  (required) template repo URI
 
 This command initiates creation of a new app based on the Mobile SDK template that you specify. The template can be a specialized app for your app type that Mobile SDK provides, or your own custom app that you've configured to use as a template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_new_project_template.htm for information on custom templates.
@@ -155,6 +143,7 @@ sfdx mobilesdk:hybrid commands: (get help with sfdx help mobilesdk:hybrid:COMMAN
  mobilesdk:hybrid:create              create a hybrid mobile application
  mobilesdk:hybrid:createwithtemplate  create a hybrid mobile application from a
                                       template
+ mobilesdk:hybrid:listtemplates       list available Mobile SDK templates
  mobilesdk:hybrid:version             show version of Mobile SDK
 
 ```
@@ -168,18 +157,12 @@ create a hybrid mobile application
 
 Flags:
  -n, --appname APPNAME            (required) application name
- -t, --apptype APPTYPE            (required) application type (hybrid_local,
-                                  hybrid_remote)
- -o, --organization ORGANIZATION  (required) organization name (your
-                                  company's/organization's name)
- -d, --outputdir OUTPUTDIR        output directory (leave empty for current
-                                  directory)
- -k, --packagename PACKAGENAME    (required) app package identifier (e.g.
-                                  com.mycompany.myapp)
- -p, --platform PLATFORM          (required) comma-separated list of platforms
-                                  (ios, android)
- -s, --startpage STARTPAGE        app start page (the start page of your remote
-                                  app; required for hybrid_remote apps only)
+ -t, --apptype APPTYPE            (required) application type (hybrid_local, hybrid_remote)
+ -o, --organization ORGANIZATION  (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR        output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME    (required) app package identifier (e.g. com.mycompany.myapp)
+ -p, --platform PLATFORM          (required) comma-separated list of platforms (ios, android)
+ -s, --startpage STARTPAGE        app start page (the start page of your remote app; required for hybrid_remote apps only)
 
 This command initiates creation of a new app based on the standard Mobile SDK template.
 
@@ -194,14 +177,10 @@ create a hybrid mobile application from a template
 
 Flags:
  -n, --appname APPNAME                  (required) application name
- -o, --organization ORGANIZATION        (required) organization name (your
-                                        company's/organization's name)
- -d, --outputdir OUTPUTDIR              output directory (leave empty for
-                                        current directory)
- -k, --packagename PACKAGENAME          (required) app package identifier (e.g.
-                                        com.mycompany.myapp)
- -p, --platform PLATFORM                (required) comma-separated list of
-                                        platforms (ios, android)
+ -o, --organization ORGANIZATION        (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR              output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME          (required) app package identifier (e.g. com.mycompany.myapp)
+ -p, --platform PLATFORM                (required) comma-separated list of platforms (ios, android)
  -r, --templaterepouri TEMPLATEREPOURI  (required) template repo URI
 
 This command initiates creation of a new app based on the Mobile SDK template that you specify. The template can be a specialized app for your app type that Mobile SDK provides, or your own custom app that you've configured to use as a template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_new_project_template.htm for information on custom templates.
@@ -217,6 +196,7 @@ sfdx mobilesdk:reactnative commands: (get help with sfdx help mobilesdk:reactnat
                                            application
  mobilesdk:reactnative:createwithtemplate  create a React Native mobile
                                            application from a template
+ mobilesdk:reactnative:listtemplates       list available Mobile SDK templates
  mobilesdk:reactnative:version             show version of Mobile SDK
 
 ```
@@ -230,14 +210,10 @@ create a React Native mobile application
 
 Flags:
  -n, --appname APPNAME            (required) application name
- -o, --organization ORGANIZATION  (required) organization name (your
-                                  company's/organization's name)
- -d, --outputdir OUTPUTDIR        output directory (leave empty for current
-                                  directory)
- -k, --packagename PACKAGENAME    (required) app package identifier (e.g.
-                                  com.mycompany.myapp)
- -p, --platform PLATFORM          (required) comma-separated list of platforms
-                                  (ios, android)
+ -o, --organization ORGANIZATION  (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR        output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME    (required) app package identifier (e.g. com.mycompany.myapp)
+ -p, --platform PLATFORM          (required) comma-separated list of platforms (ios, android)
 
 This command initiates creation of a new app based on the standard Mobile SDK template.
 
@@ -252,14 +228,10 @@ create a React Native mobile application from a template
 
 Flags:
  -n, --appname APPNAME                  (required) application name
- -o, --organization ORGANIZATION        (required) organization name (your
-                                        company's/organization's name)
- -d, --outputdir OUTPUTDIR              output directory (leave empty for
-                                        current directory)
- -k, --packagename PACKAGENAME          (required) app package identifier (e.g.
-                                        com.mycompany.myapp)
- -p, --platform PLATFORM                (required) comma-separated list of
-                                        platforms (ios, android)
+ -o, --organization ORGANIZATION        (required) organization name (your company's/organization's name)
+ -d, --outputdir OUTPUTDIR              output directory (leave empty for current directory)
+ -k, --packagename PACKAGENAME          (required) app package identifier (e.g. com.mycompany.myapp)
+ -p, --platform PLATFORM                (required) comma-separated list of platforms (ios, android)
  -r, --templaterepouri TEMPLATEREPOURI  (required) template repo URI
 
 This command initiates creation of a new app based on the Mobile SDK template that you specify. The template can be a specialized app for your app type that Mobile SDK provides, or your own custom app that you've configured to use as a template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/ios_new_project_template.htm for information on custom templates.

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -67,6 +67,17 @@ This command initiates creation of a new app based on the standard Mobile SDK te
 
 ```
 
+### List available native iOS templates
+```
+-> sfdx mobilesdk:ios:listtemplates --help
+Usage: sfdx mobilesdk:ios:listtemplates
+
+list available Mobile SDK templates
+
+This command displays the list of available Mobile SDK templates.
+
+```
+
 ### Create iOS application from template
 ```
 -> sfdx mobilesdk:ios:createwithtemplate --help
@@ -114,6 +125,17 @@ Flags:
  -k, --packagename PACKAGENAME    (required) app package identifier (e.g. com.mycompany.myapp)
 
 This command initiates creation of a new app based on the standard Mobile SDK template.
+
+```
+
+### List available native Android templates
+```
+-> sfdx mobilesdk:android:listtemplates --help
+Usage: sfdx mobilesdk:android:listtemplates
+
+list available Mobile SDK templates
+
+This command displays the list of available Mobile SDK templates.
 
 ```
 
@@ -168,6 +190,17 @@ This command initiates creation of a new app based on the standard Mobile SDK te
 
 ```
 
+### List available hybrid templates
+```
+-> sfdx mobilesdk:hybrid:listtemplates --help
+Usage: sfdx mobilesdk:hybrid:listtemplates
+
+list available Mobile SDK templates
+
+This command displays the list of available Mobile SDK templates.
+
+```
+
 ### Create hybrid application from template
 ```
 -> sfdx mobilesdk:hybrid:createwithtemplate --help
@@ -216,6 +249,17 @@ Flags:
  -p, --platform PLATFORM          (required) comma-separated list of platforms (ios, android)
 
 This command initiates creation of a new app based on the standard Mobile SDK template.
+
+```
+
+### List available React Native templates
+```
+-> sfdx mobilesdk:reactnative:listtemplates --help
+Usage: sfdx mobilesdk:reactnative:listtemplates
+
+list available Mobile SDK templates
+
+This command displays the list of available Mobile SDK templates.
 
 ```
 

--- a/sfdx/generate_readme.sh
+++ b/sfdx/generate_readme.sh
@@ -43,6 +43,8 @@ print "### Help for iOS"
 run 'sfdx mobilesdk:ios --help'
 print "### Create Objective-C (native) or Swift (native_swift) application"
 run 'sfdx mobilesdk:ios:create --help'
+print "### List available native iOS templates"
+run 'sfdx mobilesdk:ios:listtemplates --help'
 print "### Create iOS application from template"
 run 'sfdx mobilesdk:ios:createwithtemplate --help'
 
@@ -51,6 +53,8 @@ print "### Help for Android"
 run 'sfdx mobilesdk:android --help'
 print "### Create Java (native) or Kotlin (native_kotlin) application"
 run 'sfdx mobilesdk:android:create --help'
+print "### List available native Android templates"
+run 'sfdx mobilesdk:android:listtemplates --help'
 print "### Create Android application from template"
 run 'sfdx mobilesdk:android:createwithtemplate --help'
 
@@ -59,6 +63,8 @@ print "### Help for hybrid"
 run 'sfdx mobilesdk:hybrid --help'
 print "### Create hybrid application"
 run 'sfdx mobilesdk:hybrid:create --help'
+print "### List available hybrid templates"
+run 'sfdx mobilesdk:hybrid:listtemplates --help'
 print "### Create hybrid application from template"
 run 'sfdx mobilesdk:hybrid:createwithtemplate --help'
 
@@ -67,6 +73,8 @@ print "### Help for React Native"
 run 'sfdx mobilesdk:reactnative --help'
 print "### Create React Native application"
 run 'sfdx mobilesdk:reactnative:create --help'
+print "### List available React Native templates"
+run 'sfdx mobilesdk:reactnative:listtemplates --help'
 print "### Create React Native application from template"
 run 'sfdx mobilesdk:reactnative:createwithtemplate --help'
 

--- a/sfdx/generate_readme.sh
+++ b/sfdx/generate_readme.sh
@@ -7,7 +7,8 @@ echo "$1" >> README.md
 run() {
 echo "\`\`\`" >> README.md
 echo "-> $1" >> README.md
-$1 >> README.md
+# removing colors, make sure to install gnu-sed (brew install gnu-sed --with-default-names)
+$1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> README.md
 echo "\`\`\`" >> README.md
 echo "" >> README.md
 }

--- a/sfdx/index.js
+++ b/sfdx/index.js
@@ -28,7 +28,10 @@
 var SDK = require('./shared/constants'),
     createHelper = require('./shared/createHelper'),
     configHelper = require('./shared/configHelper'),
-    logError = require('./shared/utils').logError;
+    logError = require('./shared/utils').logError,
+    logInfo = require('./shared/utils').logInfo,
+    templateHelper = require('./shared/templateHelper'),
+    COLOR = require('./shared/outputColors');
 
 // Flags
 function getFlags(cli, commandName) {
@@ -60,8 +63,26 @@ function runCommand(cli, commandName, vals) {
     case SDK.commands.version.name:
         configHelper.printVersion(cli);
         break;
+    case SDK.commands.listtemplates.name:
+        listTemplates(cli);
+        process.exit(0);
+        break;
     }
 }
+
+// Sfdx's listTemplates
+function listTemplates(cli) {
+    var applicableTemplates = templateHelper.getTemplates(cli);
+
+    logInfo('\nAvailable templates:\n', COLOR.cyan);
+    for (var i=0; i<applicableTemplates.length; i++) {
+        var template = applicableTemplates[i];
+        logInfo((i+1) + ') ' + template.description, COLOR.cyan);
+        logInfo('sfdx ' +  [namespace, cli.topic, SDK.commands.createwithtemplate.name].join(':') + ' --' + SDK.args.templateRepoUri.name + '=' + template.url, COLOR.magenta);
+    }
+    logInfo('');
+}
+
 
 // Topics
 function getTopics() {
@@ -102,9 +123,12 @@ function getCommands() {
     return commands;
 }
 
+// Name space
+var namespace = 'mobilesdk';
+
 module.exports = {
     namespace: {
-        name:'mobilesdk',
+        name: namespace,
         description: 'Create mobile apps based on the Salesforce Mobile SDK'
     },
     topics: getTopics(),

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -31,7 +31,9 @@ var path = require('path'),
     SDK = require('./constants'),
     COLOR = require('./outputColors'),
     commandLineUtils = require('./commandLineUtils'),
-    logInfo = require('./utils').logInfo;
+    logInfo = require('./utils').logInfo,
+    getTemplates = require('./templateHelper').getTemplates;
+
 
 function applyCli(f, cli) {
     return typeof f === 'function' ? f(cli): f;
@@ -86,6 +88,10 @@ function readConfig(args, cli, handler) {
     case SDK.commands.createwithtemplate.name: 
         processorList = createArgsProcessorList(cli, commandName);
         break;
+    case SDK.commands.listtemplates.name:
+        listTemplates(cli);
+        process.exit(0);
+        break;
     default:
         usage(cli);
         process.exit(1);
@@ -103,6 +109,19 @@ function printArgs(cli, commandName) {
         .filter(arg => !arg.hidden)
         .forEach(arg => logInfo('    ' + (!arg.required  ? '[' : '') + '--' + arg.name + '=' + arg.description + (!arg.required ? ']' : ''), COLOR.magenta));
 }    
+
+function listTemplates(cli) {
+    var cliName = cli.name;
+    var applicableTemplates = getTemplates(cli);
+
+    logInfo('\nAvailable templates:\n', COLOR.cyan);
+    for (var i=0; i<applicableTemplates.length; i++) {
+        var template = applicableTemplates[i];
+        logInfo((i+1) + ') ' + template.description, COLOR.cyan);
+        logInfo(cliName + ' ' + SDK.commands.createwithtemplate.name + ' --' + SDK.args.templateRepoUri.name + '=' + template.url, COLOR.magenta);
+    }
+    logInfo('');
+}
 
 function usage(cli) {
     var cliName = cli.name;

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -257,8 +257,8 @@ module.exports = {
         listtemplates: {
             name: 'listtemplates',
             args: [],
-            description: 'list available Mobile SDK templates',
-            longDescription: 'List available Mobile SDK templates.',
+            description: cli => 'list available Mobile SDK templates to create ' + cli.purpose,
+            longDescription: cli => 'List available Mobile SDK templates to create ' + cli.purpose + '.',
             help: 'This command displays the list of available Mobile SDK templates.'
         }
     }

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -79,7 +79,7 @@ module.exports = {
                 'native': 'iOSNativeTemplate',
                 'native_swift': 'iOSNativeSwiftTemplate'
             },
-            commands: ['create', 'createwithtemplate', 'version']            
+            commands: ['create', 'createwithtemplate', 'version', 'listtemplates']            
         },
         forcedroid: {
             name: 'forcedroid',
@@ -93,7 +93,7 @@ module.exports = {
                 'native': 'AndroidNativeTemplate',
                 'native_kotlin': 'AndroidNativeKotlinTemplate'
             },
-            commands: ['create', 'createwithtemplate', 'version']            
+            commands: ['create', 'createwithtemplate', 'version', 'listtemplates']            
         },
         forcehybrid: {
             name: 'forcehybrid',
@@ -107,7 +107,7 @@ module.exports = {
                 'hybrid_local': 'HybridLocalTemplate',
                 'hybrid_remote': 'HybridRemoteTemplate'
             },
-            commands: ['create', 'createwithtemplate', 'version']            
+            commands: ['create', 'createwithtemplate', 'version', 'listtemplates']            
         },
         forcereact: {
             name: 'forcereact',
@@ -120,7 +120,7 @@ module.exports = {
             appTypesToPath: {
                 'react_native': 'ReactNativeTemplate'
             },
-            commands: ['create', 'createwithtemplate', 'version']
+            commands: ['create', 'createwithtemplate', 'version', 'listtemplates']
         }
     },
 
@@ -253,6 +253,13 @@ module.exports = {
             description: 'show version of Mobile SDK',
             longDescription: 'Show version of Mobile SDK.',
             help: 'This command displays to the console the version of Mobile SDK that the script uses to create apps.'
+        },
+        listtemplates: {
+            name: 'listtemplates',
+            args: [],
+            description: 'list available Mobile SDK templates',
+            longDescription: 'List available Mobile SDK templates.',
+            help: 'This command displays the list of available Mobile SDK templates.'
         }
     }
 };

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -30,19 +30,7 @@ var path = require('path'),
     SDK = require('./constants'),
     utils = require('./utils'),
     configHelper = require('./configHelper'),
-    COLOR = require('./outputColors');
-
-//
-// Helper to prepare template
-// 
-function prepareTemplate(config, templateDir) {
-    var template = require(path.join(templateDir, 'template.js'));
-    return utils.runFunctionThrowError(
-        function() {
-            return template.prepare(config, utils.replaceInFiles, utils.moveFile, utils.removeFile);
-        },
-        templateDir);
-}
+    prepareTemplate = require('./templateHelper').prepareTemplate;
 
 //
 // Helper for native application creation
@@ -273,7 +261,6 @@ function actuallyCreateApp(forcecli, config) {
         process.exit(1);
     }
 }
-
 
 module.exports = {
     createApp

--- a/shared/templateHelper.js
+++ b/shared/templateHelper.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018-present, salesforce.com, inc.
+ * All rights reserved.
+ * Redistribution and use of this software in source and binary forms, with or
+ * without modification, are permitted provided that the following conditions
+ * are met:
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of salesforce.com, inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission of salesforce.com, inc.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Dependencies
+var path = require('path'),
+    SDK = require('./constants'),
+    utils = require('./utils');
+
+//
+// Helper to prepare template
+// 
+function prepareTemplate(config, templateDir) {
+    var template = require(path.join(templateDir, 'template.js'));
+    return utils.runFunctionThrowError(
+        function() {
+            return template.prepare(config, utils.replaceInFiles, utils.moveFile, utils.removeFile);
+        },
+        templateDir);
+}
+
+//
+// Print list of available templates
+//
+function getTemplates(cli) {
+    try {
+
+        // Creating tmp dir for template clone
+        var tmpDir = utils.mkTmpDir();
+
+        // Cloning template repo
+        var repoDir = utils.cloneRepo(tmpDir, SDK.templatesRepoUri);
+        var parts = SDK.templatesRepoUri.split('#');
+        var repoUrl = parts[0];
+        var branch = parts.length > 1 ? parts[1] : 'master';
+
+        // Getting list of templates
+        var templates = require(path.join(repoDir, 'templates.json'));
+
+        // Keeping only applicable templates, adding full template url
+        var applicableTemplates = templates
+            .filter(template => cli.appTypes.includes(template.appType) && cli.platforms.filter(platform => template.platforms.includes(platform)).length > 0)
+            .map(template => {
+                template.url = repoUrl + '/' + template.path + '#' + branch;
+                return template;
+            });
+
+        // Cleanup
+        utils.removeFile(tmpDir);
+
+        return applicableTemplates;
+    }
+    catch (error) {
+        utils.logError(cli.name + ' failed\n', error);
+        process.exit(1);
+    }
+}
+
+module.exports = {
+    prepareTemplate,
+    getTemplates
+};


### PR DESCRIPTION
It returns the available and applicable templates for that cli.

It fetches the list of templates from the templates.json (see https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/121) file at the root of the template repo specified in constants.js (it will be https://github.com/forcedotcom/SalesforceMobileSDK-Template#v6.2.0 once 6.2 ships).

```shell
$ forceios listtemplates

Available templates:

1) Basic Swift application
forceios createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/iOSNativeSwiftTemplate#dev
2) Basic Objective-C application
forceios createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/iOSNativeTemplate#dev
3) Sample Swift Identity Provider application
forceios createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/iOSIDPTemplate#dev
4) Sample Swift application using SmartSync data framework
forceios createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/SmartSyncExplorerSwift#dev
```

It works also with sfdx
```shell
$ sfdx mobilesdk:android:listtemplates

Available templates:

1) Basic Kotlin application
sfdx mobilesdk:android:createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/AndroidNativeKotlinTemplate#dev
2) Basic Java application
sfdx mobilesdk:android:createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/AndroidNativeTemplate#dev
3) Sample Kotlin Identity Provider application
sfdx mobilesdk:android:createwithtemplate --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates/AndroidIDPTemplate#dev
```