### PR TITLE
Max version check for 3rd party tools

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -38,6 +38,11 @@ module.exports = {
             checkCmd: 'git --version',
             minVersion: '2.13'
         },
+        node: {
+            checkCmd: 'node --version',
+            minVersion: '6.9',
+            maxVersion: '8.11',
+        },
         npm: {
             checkCmd: 'npm -v',
             minVersion: '3.10'
@@ -74,7 +79,7 @@ module.exports = {
             purpose: 'an iOS native mobile application',
             dir: 'ios',
             platforms: ['ios'],
-            toolNames: ['git', 'npm', 'pod'],
+            toolNames: ['git', 'node', 'npm', 'pod'],
             appTypes: ['native', 'native_swift'],
             appTypesToPath: {
                 'native': 'iOSNativeTemplate',
@@ -88,7 +93,7 @@ module.exports = {
             purpose: 'an Android native mobile application',
             dir: 'android',
             platforms: ['android'],
-            toolNames: ['git', 'npm'],
+            toolNames: ['git', 'node', 'npm'],
             appTypes: ['native', 'native_kotlin'],
             appTypesToPath: {
                 'native': 'AndroidNativeTemplate',
@@ -102,7 +107,7 @@ module.exports = {
             purpose: 'a hybrid mobile application',
             dir: 'hybrid',
             platforms: ['ios', 'android'],
-            toolNames: ['git', 'npm', 'cordova'],
+            toolNames: ['git', 'node', 'npm', 'cordova'],
             appTypes: ['hybrid_local', 'hybrid_remote'],
             appTypesToPath: {
                 'hybrid_local': 'HybridLocalTemplate',
@@ -116,7 +121,7 @@ module.exports = {
             purpose: 'a React Native mobile application',
             dir: 'react',
             platforms: ['ios', 'android'],
-            toolNames: ['git', 'npm', 'pod'],
+            toolNames: ['git', 'node', 'npm', 'pod'],
             appTypes: ['react_native'],
             appTypesToPath: {
                 'react_native': 'ReactNativeTemplate'

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -44,7 +44,8 @@ module.exports = {
         },
         pod: {
             checkCmd: 'pod --version',
-            minVersion: '1.2'
+            minVersion: '1.2',
+            maxVersion: '1.4',
         },
         cordova: {
             checkCmd: 'cordova -v',

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -144,7 +144,7 @@ function checkTools(toolNames) {
     try {
         utils.log("Checking tools");
         for (var toolName of toolNames) {
-            utils.checkToolVersion(SDK.tools[toolName].checkCmd, SDK.tools[toolName].minVersion);
+            utils.checkToolVersion(SDK.tools[toolName].checkCmd, SDK.tools[toolName].minVersion, SDK.tools[toolName].maxVersion);
         }
     }
     catch (error) {

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -86,10 +86,11 @@ function getVersionNumberFromString(versionString) {
  *
  * @param {String} cmd Command to run to get the tool version
  * @param {String} minVersionRequired Minimum version required
+ * @param {String} maxVersionSupported Maximum version supported
  *
  * @throws {Error} if tool not found or version too low
  */
-function checkToolVersion(cmd, minVersionRequired) {
+function checkToolVersion(cmd, minVersionRequired, maxVersionSupported) {
     var toolName = cmd.split(' ')[0];
     var toolVersion;
     try {
@@ -106,6 +107,14 @@ function checkToolVersion(cmd, minVersionRequired) {
     if (toolVersionNum < minVersionRequiredNum) {
         throw new Error('Installed ' + toolName + ' version (' + toolVersion + ') is less than the minimum required version ('
                         + minVersionRequired + ').  Please update your version of ' + toolName + '.');
+    }
+
+    if (maxVersionSupported) {
+        var maxVersionSupportedNum = getVersionNumberFromString(maxVersionSupported);
+        if (toolVersionNum > maxVersionSupportedNum) {
+            throw new Error('Installed ' + toolName + ' version (' + toolVersion + ') is more than the maximum supported version ('
+                            + maxVersionSupported + ').  Please downgrade your version of ' + toolName + '.');
+        }
     }
 }
 


### PR DESCRIPTION
Adding max version supported (optional) in constants.js
Adding max version supported (1.4) for cocoapods
Adding min/max versions supported (6.9-8.11) for node