### PR TITLE
New param for test_force to generate/compile apps based on all available templates

### DIFF
--- a/shared/templateHelper.js
+++ b/shared/templateHelper.js
@@ -43,7 +43,7 @@ function prepareTemplate(config, templateDir) {
 }
 
 //
-// Print list of available templates
+// Get templates for the given cli
 //
 function getTemplates(cli) {
     try {
@@ -79,7 +79,33 @@ function getTemplates(cli) {
     }
 }
 
+//
+// Get appType for the given template given by its uri
+//
+function getAppTypeFromTemplate(templateRepoUriWithPossiblePath) {
+    var templateUriParsed = utils.separateRepoUrlPathBranch(templateRepoUriWithPossiblePath);
+    var templateRepoUri = templateUriParsed.repo + '#' + templateUriParsed.branch;
+    var templatePath = templateUriParsed.path;
+
+    // Creating tmp dir for template clone
+    var tmpDir = utils.mkTmpDir();
+
+    // Cloning template repo
+    var repoDir = utils.cloneRepo(tmpDir, templateRepoUri);
+
+    // Getting template
+    var appType = require(path.join(repoDir, templatePath, 'template.js')).appType;
+
+    // Cleanup
+    utils.removeFile(tmpDir);
+
+    // Done
+    return appType;
+}
+
+
 module.exports = {
     prepareTemplate,
-    getTemplates
+    getTemplates,
+    getAppTypeFromTemplate
 };

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -282,8 +282,9 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
     var isReactNative = actualAppType === APP_TYPE.react_native;
     var isHybrid = actualAppType.indexOf('hybrid') == 0;
     var isHybridRemote = actualAppType === APP_TYPE.hybrid_remote;
-    var target = actualAppType + ' app for ' + os + (templateRepoUri ? ' based on template ' + getTemplateNameFromUri(templateRepoUri) : '');
-    var appName = actualAppType + '_' + os + 'App';
+    var templateName = getTemplateNameFromUri(templateRepoUri);
+    var target = actualAppType + ' app for ' + os + (templateRepoUri ? ' based on template ' + templateName : '');
+    var appName = 'App_' + templateName.replace('#', '_') + '_' + os;
     // Add app type unless the app is native or react native iOS
     var packageSuffix = (os === OS.ios && !isHybrid) ? '' : '.' + actualAppType;
     // "native" is an illegal word for android package

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -95,6 +95,11 @@ function main(args) {
             }
         }
         else {
+            // Getting appType if template specified
+            if (testingWithTemplate) {	
+                chosenAppTypes = [templateHelper.getAppTypeFromTemplate(templateRepoUri)];
+            }
+            
             for (var cliName in SDK.forceclis) {
                 var cli = SDK.forceclis[cliName];
                 if (cli.platforms.some(p=>chosenOperatingSystems.indexOf(p)>=0)
@@ -156,9 +161,10 @@ function main(args) {
                     createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested);
                 }
             }
-
+            
             if (testingWithTemplate) {
-                createCompileApp(tmpDir, os, templateHelper.getAppTypeFromTemplate(templateRepoUri), templateRepoUri, null, useSfdxRequested);
+                // NB: chosenAppTypes[0] is appType from template
+                createCompileApp(tmpDir, os, chosenAppTypes[0], templateRepoUri, null, useSfdxRequested);
             }
         }
     }

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -9,6 +9,7 @@ var spawnSync = require('child_process').spawnSync,
     shelljs = require('shelljs'),
     commandLineUtils = require('../shared/commandLineUtils'),
     utils = require('../shared/utils'),
+    templateHelper = require('../shared/templateHelper.js'),
     SDK = require('../shared/constants'),
     COLOR = require('../shared/outputColors'),
     SDK = require('../shared/constants')
@@ -46,35 +47,34 @@ function main(args) {
     var testProduction = parsedArgs.hasOwnProperty('test-production');
     var useSfdxRequested = parsedArgs.hasOwnProperty('use-sfdx');
     var chosenOperatingSystems = cleanSplit(parsedArgs.os, ',').map(function(s) { return s.toLowerCase(); });
-    var appTypes = parsedArgs.apptype || '';
     var templateRepoUri = parsedArgs.templaterepouri || '';
     var pluginRepoUri = !testProduction ? (parsedArgs.pluginrepouri || SDK.tools.cordova.pluginRepoUri) : '';
     var sdkBranch = parsedArgs.sdkbranch || defaultSdkBranch;
     var chosenAppTypes = cleanSplit(parsedArgs.apptype, ',');
+    var chosenClis = cleanSplit(parsedArgs.cli, ',');
 
-    var testingWithAppType = chosenAppTypes.length > 0 && templateRepoUri == '';
+    var testingWithOS = chosenOperatingSystems.length > 0;
+    var testingWithClis = chosenClis.length > 0;    
+    var testingWithAppType = chosenAppTypes.length > 0;
     var testingWithTemplate = templateRepoUri != '';
+
     var testingIOS = chosenOperatingSystems.indexOf(OS.ios) >= 0;
     var testingAndroid = chosenOperatingSystems.indexOf(OS.android) >= 0;
     var testingHybrid = chosenAppTypes.some(t=>t.indexOf("hybrid") >= 0);
-
-    // Validation
-    validateOperatingSystems(chosenOperatingSystems);
-    validateAppTypesTemplateRepoUri(chosenAppTypes, templateRepoUri);
 
     // Usage
     if (usageRequested) {
         usage(0);
     }
 
+    // Validation
+    validateOperatingSystemsClis(chosenOperatingSystems, chosenClis);
+    validateAppTypesTemplateRepoUri(testingWithOS, chosenAppTypes, templateRepoUri);
+
     // Actual testing
     var tmpDir = utils.mkTmpDir();
 
-    // Getting appType if template specified
-    if (testingWithTemplate) {
-        chosenAppTypes = [getAppTypeFromTemplate(templateRepoUri)];
-    }
-
+    // Install sfdx plugin or force clis
     if (useSfdxRequested) {
         if (testProduction) {
             // Install publised sfdx plugin
@@ -86,20 +86,36 @@ function main(args) {
         }
     }
     else {
-        for (var cliName in SDK.forceclis) {
-            var cli = SDK.forceclis[cliName];
-            if (cli.platforms.some(p=>chosenOperatingSystems.indexOf(p)>=0)
-                && cli.appTypes.some(a=>chosenAppTypes.indexOf(a)>=0)) {
+        var forceClis= [];
 
-                if (testProduction) {
-                    // Install forcexxx package
-                    installPublishedForceCli(tmpDir, cli);
-                }
-                else {
-                    // Create forcexxx packages needed
-                    createDeployForcePackage(tmpDir, cli);
-                }
+        if (testingWithClis) {
+            for (var i=0; i<chosenClis.length; i++) {
+                var cliName = chosenClis[i];
+                forceClis.push(SDK.forceclis[cliName]);
+            }
+        }
+        else {
+            for (var cliName in SDK.forceclis) {
+                var cli = SDK.forceclis[cliName];
+                if (cli.platforms.some(p=>chosenOperatingSystems.indexOf(p)>=0)
+                    && cli.appTypes.some(a=>chosenAppTypes.indexOf(a)>=0)) {
 
+                    forceClis.push(cli);
+                }
+            }
+        }
+
+
+        for (var i=0; i<forceClis.length; i++) {
+            var cli = forceClis[i];
+            
+            if (testProduction) {
+                // Install forcexxx package
+                installPublishedForceCli(tmpDir, cli);
+            }
+            else {
+                // Create forcexxx packages needed
+                createDeployForcePackage(tmpDir, cli);
             }
         }
     }
@@ -118,17 +134,32 @@ function main(args) {
     }
 
     // Test all the platforms / app types requested
-    for (var i=0; i<chosenOperatingSystems.length; i++) {
-        var os = chosenOperatingSystems[i];
-        if (testingWithAppType) {
-            for (var j=0; j<chosenAppTypes.length; j++) {
-                var appType = chosenAppTypes[j];
-                createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested);
+    if (testingWithClis) {
+        for (var i=0; i<chosenClis.length; i++) {
+            var cliName = chosenClis[i];
+            var templates = templateHelper.getTemplates(SDK.forceclis[cliName]);
+            for (var j=0; j<templates.length; j++) {
+                var template = templates[j];
+                for (var k=0; k<template.platforms.length; k++) {
+                    var os = template.platforms[k];
+                    createCompileApp(tmpDir, os, template.appType, template.url, null, useSfdxRequested);
+                }
             }
         }
-        if (testingWithTemplate) {
-            // NB: chosenAppTypes[0] is getAppTypeFromTemplate(templateRepoUri)
-            createCompileApp(tmpDir, os, chosenAppTypes[0], templateRepoUri, null, useSfdxRequested);
+    }
+    else {
+        for (var i=0; i<chosenOperatingSystems.length; i++) {
+            var os = chosenOperatingSystems[i];
+            if (testingWithAppType) {
+                for (var j=0; j<chosenAppTypes.length; j++) {
+                    var appType = chosenAppTypes[j];
+                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested);
+                }
+            }
+
+            if (testingWithTemplate) {
+                createCompileApp(tmpDir, os, templateHelper.getAppTypeFromTemplate(templateRepoUri), templateRepoUri, null, useSfdxRequested);
+            }
         }
     }
 }
@@ -136,13 +167,13 @@ function main(args) {
 //
 // Usage
 //
-function usage(exitCode) {
+function shortUsage(exitCode) {
     utils.logInfo('Usage:\n',  COLOR.cyan);
     utils.logInfo('  test_force.js --usage', COLOR.magenta);
     utils.logInfo('\n OR \n', COLOR.cyan);
     utils.logInfo('  test_force.js', COLOR.magenta);
-    utils.logInfo('    --os=os1,os2,etc', COLOR.magenta);
-    utils.logInfo('    --apptype=appType1,appType2,etc OR --templaterepouri=TEMPLATE_REPO_URI', COLOR.magenta);
+    utils.logInfo('    --os=os1,os2,etc  OR --cli=cli1,cli2,etc', COLOR.magenta);
+    utils.logInfo('    (when using --os) --apptype=appType1,appType2,etc OR --templaterepouri=TEMPLATE_REPO_URI', COLOR.magenta);
     utils.logInfo('    [--use-sfdx]', COLOR.magenta);
     utils.logInfo('    [--test-production]', COLOR.magenta);
     utils.logInfo('    [--pluginrepouri=PLUGIN_REPO_URI (Defaults to uri in shared/constants.js)]', COLOR.magenta);
@@ -150,30 +181,45 @@ function usage(exitCode) {
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);
+    utils.logInfo('  - cliX is : forceios or forcedroid or forcehybrid or forcereact', COLOR.cyan);
     utils.logInfo('  - appTypeX is: native, native_swift, native_kotlin, react_native, hybrid_local or hybrid_remote', COLOR.cyan);
     utils.logInfo('  - templaterepouri is a template repo uri e.g. https://github.com/forcedotcom/SalesforceMobileSDK-Templates/SmartSyncExplorerReactNative#dev', COLOR.cyan);
+    utils.logInfo('', COLOR.cyan);
+
+    if (typeof(exitCode) !== 'undefined') {
+        process.exit(exitCode);
+    }
+}
+
+function usage(exitCode) {
+    shortUsage();
+    
+    utils.logInfo('  If a cli is targeted:', COLOR.cyan);
+    utils.logInfo('  - generates cli package and deploys it to a temporary directory', COLOR.cyan);
+    utils.logInfo('  - fetches list of applicable templates for that cli', COLOR.cyan);
+    utils.logInfo('  - creates and compiles applications for specified operating systems and applicable templates', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If hybrid is targeted:', COLOR.cyan);
     utils.logInfo('  - clones PLUGIN_REPO_URI ', COLOR.cyan);
     utils.logInfo('  - runs ./tools/update.sh -b SDK_BRANCH to update clone of plugin repo', COLOR.cyan);
     utils.logInfo('  - generates forcehybrid package and deploys it to a temporary directory', COLOR.cyan);
-    utils.logInfo('  - creates and compiles applications for the specified os, template and plugin', COLOR.cyan);
+    utils.logInfo('  - creates and compiles applications for specified operating systems, template and plugin', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If apptype is react_native:', COLOR.cyan);
     utils.logInfo('  - generates forcereact package and deploys it to a temporary directory', COLOR.cyan);
-    utils.logInfo('  - creates and compiles applications for the specified os and template', COLOR.cyan);
+    utils.logInfo('  - creates and compiles applications for specified operating systems and template', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If ios is targeted (and apptype is a native type):', COLOR.cyan);
     utils.logInfo('  - generates forceios package and deploys it to a temporary directory', COLOR.cyan);
-    utils.logInfo('  - creates and compiles applications for the specified os and template', COLOR.cyan);
+    utils.logInfo('  - creates and compiles applications for specified operating systems and template', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If android is targeted (and apptype is a native type):', COLOR.cyan);
     utils.logInfo('  - generates forcedroid package and deploys it to a temporary directory', COLOR.cyan);
-    utils.logInfo('  - creates and compiles applications for the specified os and template', COLOR.cyan);
+    utils.logInfo('  - creates and compiles applications for specified operating systems and template', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If use-sfdx is specified, then the sfdx-mobilesdk-plugin package is generated and used through sfdx for creating the applications', COLOR.cyan);
+    utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If test-production is specified, then the published forceios/forcedroid/forcehybrid/forcereact/sfdx-mobilesdk-plugin are used', COLOR.cyan);
-
 
     process.exit(exitCode);
 }
@@ -334,34 +380,51 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
 //
 // Helper to validate operating systems
 //
-function validateOperatingSystems(chosenOperatingSystems) {
-    if (chosenOperatingSystems.length == 0) {
-        utils.logError('You need to specify at least one os\n');
-        usage(1);
+function validateOperatingSystemsClis(chosenOperatingSystems, chosenClis) {
+    if (!(chosenOperatingSystems.length == 0 ^ chosenClis.length == 0)) {
+        utils.logError('You need to specify at least one os or one cli (but not both)\n');
+        shortUsage(1);
     }
     for (var i=0; i<chosenOperatingSystems.length; i++) {
         var os = chosenOperatingSystems[i];
         if (!OS.hasOwnProperty(os) || (isWindows() && os === OS.ios)) {
             utils.logError('Invalid os: ' + os + '\n');
-            usage(1);
+            shortUsage(1);
         }
     }
+
+    for (var i=0; i<chosenClis.length; i++) {
+        var cliName = chosenClis[i];
+        if (!SDK.forceclis.hasOwnProperty(cliName)) {
+            utils.logError('Invalid cli: ' + cliName + '\n');
+            shortUsage(1);
+        }
+    }
+
 }
 
 //
 // Helper to validate app types / template repo uri
 //
-function validateAppTypesTemplateRepoUri(chosenAppTypes, templateRepoUri) {
-    if (!(chosenAppTypes.length == 0 ^ templateRepoUri === '')) {
-        utils.logError('You need to specify apptype or templaterepouri (but not both)\n');
-        usage(1);
-    }
+function validateAppTypesTemplateRepoUri(testingWithOS, chosenAppTypes, templateRepoUri) {
+    if (testingWithOS) {
+        if (!(chosenAppTypes.length == 0 ^ templateRepoUri === '')) {
+            utils.logError('You need to specify apptype or templaterepouri (but not both)\n');
+            shortUsage(1);
+        }
 
-    for (var i=0; i<chosenAppTypes.length; i++) {
-        var appType = chosenAppTypes[i];
-        if (!APP_TYPE.hasOwnProperty(appType)) {
-            utils.logError('Invalid appType: ' + appType + '\n');
-            usage(1);
+        for (var i=0; i<chosenAppTypes.length; i++) {
+            var appType = chosenAppTypes[i];
+            if (!APP_TYPE.hasOwnProperty(appType)) {
+                utils.logError('Invalid appType: ' + appType + '\n');
+                shortUsage(1);
+            }
+        }
+    }
+    else {
+        if (chosenAppTypes.length != 0 || templateRepoUri !== '') {
+            utils.logError('You only need to specify apptype or templaterepouri with --os\n');
+            shortUsage(1);
         }
     }
 }
@@ -394,29 +457,4 @@ function isWindows() {
 function getTemplateNameFromUri(templateRepoUri) {
     var parts = templateRepoUri.split('/');
     return parts[parts.length-1];
-}
-
-
-//
-// Get template apptype
-//
-function getAppTypeFromTemplate(templateRepoUriWithPossiblePath) {
-    var templateUriParsed = utils.separateRepoUrlPathBranch(templateRepoUriWithPossiblePath);
-    var templateRepoUri = templateUriParsed.repo + '#' + templateUriParsed.branch;
-    var templatePath = templateUriParsed.path;
-
-    // Creating tmp dir for template clone
-    var tmpDir = utils.mkTmpDir();
-
-    // Cloning template repo
-    var repoDir = utils.cloneRepo(tmpDir, templateRepoUri);
-
-    // Getting template
-    var appType = require(path.join(repoDir, templatePath, 'template.js')).appType;
-
-    // Cleanup
-    utils.removeFile(tmpDir);
-
-    // Done
-    return appType;
 }


### PR DESCRIPTION
Usage is now:
```shell
  test_force.js
    --os=os1,os2,etc  OR --cli=cli1,cli2,etc
    (when using --os) --apptype=appType1,appType2,etc OR --templaterepouri=TEMPLATE_REPO_URI
    [--use-sfdx]
    [--test-production]
    [--pluginrepouri=PLUGIN_REPO_URI (Defaults to uri in shared/constants.js)]
    [--sdkbranch=SDK_BRANCH (Defaults to dev)]

  Where:
  - osX is : ios or android
  - cliX is : forceios or forcedroid or forcehybrid or forcereact
  - appTypeX is: native, native_swift, native_kotlin, react_native, hybrid_local or hybrid_remote
  - templaterepouri is a template repo uri e.g. https://github.com/forcedotcom/SalesforceMobileSDK-Templates/SmartSyncExplorerReactNative#dev
```

For example, to generate/compile all templates available to forcedroid (including basic templates), do:
```shell
./test/test_force.js --cli=forcedroid
```

Of course, you can specify more than one clis:
```shell
./test/test_force.js --cli=forceios,forcedroid
```
