### PR TITLE
Max version of node supported moved to 11.1

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -41,7 +41,7 @@ module.exports = {
         node: {
             checkCmd: 'node --version',
             minVersion: '6.9',
-            maxVersion: '10.11'
+            maxVersion: '11.1'
         },
         npm: {
             checkCmd: 'npm -v',


### PR DESCRIPTION
Node lts is [now](https://medium.com/@nodejs/october-brings-node-js-10-x-to-lts-and-node-js-11-to-current-ae19f8f12b51) 10.x and current is 11.x.
I tested 11.1 and didn't run into any issues.