### PR TITLE
Dropping max version check for node

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -40,8 +40,7 @@ module.exports = {
         },
         node: {
             checkCmd: 'node --version',
-            minVersion: '6.9',
-            maxVersion: '11.1'
+            minVersion: '6.9'
         },
         npm: {
             checkCmd: 'npm -v',


### PR DESCRIPTION
Two reasons
1) our use of node is very basic (we no longer pull dependencies with node instead we use git) so unlikely to break
2) there are new versions of node all the time, it's very annoying to get the `Please downgrade your version of node.` message when running one of the force tool.