### PR TITLE
Handling version number that starts with other characters

### DIFF
--- a/shared/utils.js
+++ b/shared/utils.js
@@ -70,7 +70,7 @@ function setLogLevel(logLevel) {
  */
 function getVersionNumberFromString(versionString) {
 	// Only supporting major/minor version checking at this point.
-	var versionRegex = /^[^\d]*(\d+)(\.(\d+))?.*$/;
+    var versionRegex = new RegExp(/^[^\d]*(\d+)(\.(\d+))?.*$/, 'm');
 	var matchArray = versionString.match(versionRegex);
 	if (matchArray === null) {
 		log(LOG_LEVELS.WARN, 'Invalid version string "' + versionString + '". Should be in the format x[.y[.ignored]]');


### PR DESCRIPTION
Now it will work with new lines in the version string like Cordova's (when run for the first time).