### PR TITLE
Fixing test_force.js to test CLIs about to or already published to production

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forcedroid",
-	"version": "7.2.0",
+	"version": "7.1.2",
 	"description": "Utilities for creating mobile apps based on the Salesforce Mobile SDK for Android",
 	"keywords": [ "mobilesdk", "android", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-Android",

--- a/hybrid/package.json
+++ b/hybrid/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forcehybrid",
-	"version": "7.2.0",
+	"version": "7.1.2",
 	"description": "Utilities for creating hybrid mobile apps based on the Salesforce Mobile SDK for iOS and Android",
 	"keywords": [ "mobilesdk", "ios", "android", "hybrid", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-Package",

--- a/ios/package.json
+++ b/ios/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forceios",
-	"version": "7.2.0",
+	"version": "7.1.2",
 	"description": "Utilities for creating mobile apps based on the Salesforce Mobile SDK for iOS",
 	"keywords": [ "mobilesdk", "ios", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forcereact",
-	"version": "7.2.0",
+	"version": "7.1.2",
 	"description": "Utilities for creating react native mobile apps based on the Salesforce Mobile SDK for iOS and Android",
 	"keywords": [ "mobilesdk", "ios", "android", "react", "salesforce", "mobile", "sdk" ],
 	"homepage": "https://github.com/forcedotcom/SalesforceMobileSDK-Package",

--- a/sfdx/package.json
+++ b/sfdx/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sfdx-mobilesdk-plugin",
-    "version": "7.2.0",
+    "version": "7.1.2",
     "description": "Sfdx plugin for creating mobile apps based on the Salesforce Mobile SDK",
     "keywords": [
         "mobilesdk",

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -28,7 +28,7 @@
 var path = require('path'),
     shelljs = require('shelljs');
 
-var VERSION = '7.1.2';
+var VERSION= '7.1.2';
 
 module.exports = {
     version: VERSION,
@@ -55,7 +55,7 @@ module.exports = {
             checkCmd: 'cordova -v',
             pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#dev',    // dev
             minVersion: '8.1.2',
-            // pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#v' + VERSION, // GA
+//             pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#v' + VERSION, // GA
             platformVersion: {
                 ios: '5.0.0',
                 android: '8.0.0'
@@ -69,7 +69,7 @@ module.exports = {
     },
 
     templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev',    // dev
-    // templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#v' + VERSION, // GA
+//     templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#v' + VERSION, // GA
 
     forceclis: {
         forceios: {

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-// Defaults
-var defaultSdkBranch = 'dev';
-
 // Dependencies
 var spawnSync = require('child_process').spawnSync,
     path = require('path'),
@@ -43,13 +40,11 @@ function main(args) {
 
     // Args extraction
     var usageRequested = parsedArgs.hasOwnProperty('usage');
-    var testProduction = parsedArgs.hasOwnProperty('test-production');
     var useSfdxRequested = parsedArgs.hasOwnProperty('use-sfdx');
     var exitOnFailure = parsedArgs.hasOwnProperty('exit-on-failure');
     var chosenOperatingSystems = cleanSplit(parsedArgs.os, ',').map(function(s) { return s.toLowerCase(); });
     var templateRepoUri = parsedArgs.templaterepouri || '';
-    var pluginRepoUri = !testProduction ? (parsedArgs.pluginrepouri || SDK.tools.cordova.pluginRepoUri) : '';
-    var sdkBranch = parsedArgs.sdkbranch || defaultSdkBranch;
+    var pluginRepoUri = parsedArgs.pluginrepouri || SDK.tools.cordova.pluginRepoUri;
     var chosenAppTypes = cleanSplit(parsedArgs.apptype, ',');
     var chosenClis = cleanSplit(parsedArgs.cli, ',');
 
@@ -76,14 +71,8 @@ function main(args) {
 
     // Install sfdx plugin or force clis
     if (useSfdxRequested) {
-        if (testProduction) {
-            // Install publised sfdx plugin
-            installPublishedSfdxPlugin(tmpDir);
-        }
-        else {
-            // Create sfdx plugin
-            createDeploySfdxPluginPackage(tmpDir);
-        }
+        // Create sfdx plugin
+        createDeploySfdxPluginPackage(tmpDir);
     }
     else {
         var forceClis= [];
@@ -114,25 +103,19 @@ function main(args) {
         for (var i=0; i<forceClis.length; i++) {
             var cli = forceClis[i];
 
-            if (testProduction) {
-                // Install forcexxx package
-                installPublishedForceCli(tmpDir, cli);
-            }
-            else {
-                // Create forcexxx packages needed
-                createDeployForcePackage(tmpDir, cli);
-            }
+            // Create forcexxx packages needed
+            createDeployForcePackage(tmpDir, cli);
         }
     }
 
     // Get cordova plugin repo if any hybrid testing requested
     if (testingHybrid) {
-        if (!testProduction && pluginRepoUri.indexOf('//') >= 0) {
-            // Actual uri - clone repo - run tools/update.sh
+        var sdkBranch = utils.separateRepoUrlPathBranch(pluginRepoUri).branch;
+
+        // Using updated local clone of plugin repo if pluginRepoUri does not point to tag
+        if (!pluginRepoUri.indexOf('//') >= 0 && !sdkBranch.match(/v[0-9.]+/)) {
             var pluginRepoDir = utils.cloneRepo(tmpDir, pluginRepoUri);
-            if (testingIOS && testingAndroid) updatePluginRepo(tmpDir, 'all', pluginRepoDir, sdkBranch);
-            if (testingIOS && !testingAndroid) updatePluginRepo(tmpDir, OS.ios, pluginRepoDir, sdkBranch);
-            if (testingAndroid && !testingIOS) updatePluginRepo(tmpDir, OS.android, pluginRepoDir, sdkBranch);
+            updatePluginRepo(tmpDir, pluginRepoDir, sdkBranch);
             // Use local updated clone of plugin
             pluginRepoUri = pluginRepoDir;
         }
@@ -188,10 +171,8 @@ function shortUsage(exitCode) {
     utils.logInfo('    --os=os1,os2,etc  OR --cli=cli1,cli2,etc', COLOR.magenta);
     utils.logInfo('    (when using --os) --apptype=appType1,appType2,etc OR --templaterepouri=TEMPLATE_REPO_URI', COLOR.magenta);
     utils.logInfo('    [--use-sfdx]', COLOR.magenta);
-    utils.logInfo('    [--test-production]', COLOR.magenta);
     utils.logInfo('    [--exit-on-failure]', COLOR.magenta);
     utils.logInfo('    [--pluginrepouri=PLUGIN_REPO_URI (Defaults to uri in shared/constants.js)]', COLOR.magenta);
-    utils.logInfo('    [--sdkbranch=SDK_BRANCH (Defaults to dev)]', COLOR.magenta);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);
@@ -214,8 +195,7 @@ function usage(exitCode) {
     utils.logInfo('  - creates and compiles applications for specified operating systems and applicable templates', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If hybrid is targeted:', COLOR.cyan);
-    utils.logInfo('  - clones PLUGIN_REPO_URI ', COLOR.cyan);
-    utils.logInfo('  - runs ./tools/update.sh -b SDK_BRANCH to update clone of plugin repo', COLOR.cyan);
+    utils.logInfo('  - if plugin_repo_uri points to a branch, use local clone of plugin repo (where we first run ./tools/update.sh)', COLOR.cyan);
     utils.logInfo('  - generates forcehybrid package and deploys it to a temporary directory', COLOR.cyan);
     utils.logInfo('  - creates and compiles applications for specified operating systems, template and plugin', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
@@ -232,8 +212,6 @@ function usage(exitCode) {
     utils.logInfo('  - creates and compiles applications for specified operating systems and template', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  If use-sfdx is specified, then the sfdx-mobilesdk-plugin package is generated and used through sfdx for creating the applications', COLOR.cyan);
-    utils.logInfo('', COLOR.cyan);
-    utils.logInfo('  If test-production is specified, then the published forceios/forcedroid/forcehybrid/forcereact/sfdx-mobilesdk-plugin are used', COLOR.cyan);
 
     process.exit(exitCode);
 }
@@ -246,14 +224,6 @@ function createDeployForcePackage(tmpDir, forcecli) {
     utils.runProcessThrowError('node ' + packJs + ' --cli=' + forcecli.name);
     utils.logInfo('Npm installing ' + forcecli.name + '-' + SDK.version + '.tgz', COLOR.green);
     utils.runProcessThrowError('npm install --prefix ' + tmpDir + ' ' + forcecli.name + '-' + SDK.version + '.tgz');
-}
-
-//
-// Install published forceios/forcedroid/forcehybrid/forcereact
-//
-function installPublishedForceCli(tmpDir, forcecli) {
-    utils.logInfo('Npm installing ' + forcecli.name, COLOR.green);
-    utils.runProcessThrowError('npm install --prefix ' + tmpDir + ' ' + forcecli.name);
 }
 
 //
@@ -272,12 +242,12 @@ function createDeploySfdxPluginPackage(tmpDir) {
 
     utils.runProcessThrowError(`ls ${oclifManifestPath}`);
 
-    console.log(`Copying file: ${oclifManifestPath} to ${mobileSdkTmpPath}`);
+    utils.logInfo(`Copying file: ${oclifManifestPath} to ${mobileSdkTmpPath}`, COLOR.green);
 
     // Gotta copy the oclif manifest to the target link folder.
     utils.runProcessThrowError(`cp ${oclifManifestPath} ${mobileSdkTmpPath}`);
     utils.runProcessThrowError('sfdx plugins:link ' + tmpDir + '/node_modules/sfdx-mobilesdk-plugin');
-    console.log('-- Finished plugins link --');
+    utils.logInfo('-- Finished plugins link --', COLOR.green);
 }
 
 //
@@ -293,9 +263,9 @@ function installPublishedSfdxPlugin(tmpDir) {
 //
 // Update cordova plugin repo
 //
-function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
+function updatePluginRepo(tmpDir, pluginRepoDir, sdkBranch) {
     utils.logInfo('Updating cordova plugin at ' + sdkBranch, COLOR.green);
-    utils.runProcessThrowError(path.join('tools', 'update.sh') + ' -b ' + sdkBranch + ' -o ' + os, pluginRepoDir);
+    utils.runProcessThrowError(path.join('tools', 'update.sh') + ' -b ' + sdkBranch, pluginRepoDir);
 }
 
 function cleanName(name) {

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -115,7 +115,9 @@ function main(args) {
         // Using updated local clone of plugin repo if pluginRepoUri does not point to tag
         if (!pluginRepoUri.indexOf('//') >= 0 && !sdkBranch.match(/v[0-9.]+/)) {
             var pluginRepoDir = utils.cloneRepo(tmpDir, pluginRepoUri);
-            updatePluginRepo(tmpDir, pluginRepoDir, sdkBranch);
+            if (testingIOS && testingAndroid) updatePluginRepo(tmpDir, 'all', pluginRepoDir, sdkBranch);
+            if (testingIOS && !testingAndroid) updatePluginRepo(tmpDir, OS.ios, pluginRepoDir, sdkBranch);
+            if (testingAndroid && !testingIOS) updatePluginRepo(tmpDir, OS.android, pluginRepoDir, sdkBranch);
             // Use local updated clone of plugin
             pluginRepoUri = pluginRepoDir;
         }
@@ -263,9 +265,9 @@ function installPublishedSfdxPlugin(tmpDir) {
 //
 // Update cordova plugin repo
 //
-function updatePluginRepo(tmpDir, pluginRepoDir, sdkBranch) {
+function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
     utils.logInfo('Updating cordova plugin at ' + sdkBranch, COLOR.green);
-    utils.runProcessThrowError(path.join('tools', 'update.sh') + ' -b ' + sdkBranch, pluginRepoDir);
+    utils.runProcessThrowError(path.join('tools', 'update.sh') + ' -b ' + sdkBranch + ' -o ' + os, pluginRepoDir);
 }
 
 function cleanName(name) {


### PR DESCRIPTION
Got rid rid of --test-production and --sdkbranch:
* sdk branch is inferred from pluginrepouri
* local updated clone of plugin repo is only used if pluginrepouri does not point to tag

=> to test production, simply run ./test_force.js in master - it will still create npm packages but they should be the ones about to or already published to production