### PR TITLE
test_force.js has a new option --no-plugin-update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,7 @@ jobs:
       - run:
           name: Building all ios hybrid templates
           command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --no-plugin-update
+          no_output_timeout: 20m
           when: always
 
   forcehybrid-ios-sfdx:
@@ -187,6 +188,7 @@ jobs:
       - run:
           name: Building all ios hybrid templates with SFDX
           command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --use-sfdx --no-plugin-update
+          no_output_timeout: 20m
           when: always
 
   forcereact-ios:
@@ -198,6 +200,7 @@ jobs:
       - run:
           name: Building all ios react native templates
           command: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios
+          no_output_timeout: 20m
           when: always
 
   forcereact-ios-sfdx:
@@ -210,6 +213,7 @@ jobs:
       - run:
           name: Building all ios react native templates with SFDX
           command: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios --use-sfdx
+          no_output_timeout: 20m
           when: always
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ linux: &linux
 mac: &mac
   working_directory: ~/SalesforceMobileSDK-Package
   macos:
-    xcode: "10.3.0"
+    xcode: "11.0.0"
   shell: /bin/bash --login -eo pipefail
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run: *android-cordova
       - run:
           name: Building all android hybrid templates
-          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android
+          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --no-plugin-update
           when: always
 
   forcehybrid-android-sfdx:
@@ -115,7 +115,7 @@ jobs:
       - run: *install-sfdx
       - run:
           name: Building all android hybrid templates with SFDX
-          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --use-sfdx
+          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --use-sfdx --no-plugin-update
           when: always
 
   forcereact-android:
@@ -173,7 +173,7 @@ jobs:
       - run: *install-ant
       - run:
           name: Building all ios hybrid templates
-          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios
+          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --no-plugin-update
           when: always
 
   forcehybrid-ios-sfdx:
@@ -186,7 +186,7 @@ jobs:
       - run: *install-sfdx
       - run:
           name: Building all ios hybrid templates with SFDX
-          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --use-sfdx
+          command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --use-sfdx --no-plugin-update
           when: always
 
   forcereact-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,6 @@ aliases:
       sudo npm install -g cordova@8.1.2
       sudo cordova telemetry off
 
-  - &install-ant
-    name: Install Ant
-    command: brew install ant
-
   - &install-sfdx
     name: Install SFDX
     command: |
@@ -146,7 +142,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *install-ant
       - run:
           name: Building all ios native templates
           command:  ./test/test_force.js --exit-on-failure --cli=forceios
@@ -157,7 +152,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *install-ant
       - run: *install-sfdx
       - run:
           name: Building all ios native templates with SFDX
@@ -170,11 +164,9 @@ jobs:
       - checkout
       - run: *setup
       - run: *ios-cordova
-      - run: *install-ant
       - run:
           name: Building all ios hybrid templates
           command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --no-plugin-update
-          no_output_timeout: 20m
           when: always
 
   forcehybrid-ios-sfdx:
@@ -183,12 +175,10 @@ jobs:
       - checkout
       - run: *setup
       - run: *ios-cordova
-      - run: *install-ant
       - run: *install-sfdx
       - run:
           name: Building all ios hybrid templates with SFDX
           command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --use-sfdx --no-plugin-update
-          no_output_timeout: 20m
           when: always
 
   forcereact-ios:
@@ -196,11 +186,9 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *install-ant
       - run:
           name: Building all ios react native templates
           command: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios
-          no_output_timeout: 20m
           when: always
 
   forcereact-ios-sfdx:
@@ -208,12 +196,10 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *install-ant
       - run: *install-sfdx
       - run:
           name: Building all ios react native templates with SFDX
           command: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios --use-sfdx
-          no_output_timeout: 20m
           when: always
 
 workflows:

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -41,6 +41,7 @@ function main(args) {
     // Args extraction
     var usageRequested = parsedArgs.hasOwnProperty('usage');
     var useSfdxRequested = parsedArgs.hasOwnProperty('use-sfdx');
+    var noPluginUpdate = parsedArgs.hasOwnProperty('no-plugin-update');
     var exitOnFailure = parsedArgs.hasOwnProperty('exit-on-failure');
     var chosenOperatingSystems = cleanSplit(parsedArgs.os, ',').map(function(s) { return s.toLowerCase(); });
     var templateRepoUri = parsedArgs.templaterepouri || '';
@@ -112,8 +113,8 @@ function main(args) {
     if (testingHybrid) {
         var sdkBranch = utils.separateRepoUrlPathBranch(pluginRepoUri).branch;
 
-        // Using updated local clone of plugin repo if pluginRepoUri does not point to tag
-        if (!pluginRepoUri.indexOf('//') >= 0 && !sdkBranch.match(/v[0-9.]+/)) {
+        // Using updated local clone of plugin repo if pluginRepoUri does not point to tag and noPluginUpdate is false
+        if (!pluginRepoUri.indexOf('//') >= 0 && !sdkBranch.match(/v[0-9.]+/) && !noPluginUpdate) {
             var pluginRepoDir = utils.cloneRepo(tmpDir, pluginRepoUri);
             if (testingIOS && testingAndroid) updatePluginRepo(tmpDir, 'all', pluginRepoDir, sdkBranch);
             if (testingIOS && !testingAndroid) updatePluginRepo(tmpDir, OS.ios, pluginRepoDir, sdkBranch);
@@ -175,6 +176,7 @@ function shortUsage(exitCode) {
     utils.logInfo('    [--use-sfdx]', COLOR.magenta);
     utils.logInfo('    [--exit-on-failure]', COLOR.magenta);
     utils.logInfo('    [--pluginrepouri=PLUGIN_REPO_URI (Defaults to uri in shared/constants.js)]', COLOR.magenta);
+    utils.logInfo('    [--no-plugin-update]', COLOR.magenta);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);


### PR DESCRIPTION
When provided, we don't run ./tools/update.sh on the clone of the plugin repo when testing forcehybrid
Using that new option in CI to speed testing up.

In the past, cordova plugin repo had binaries, and we only updated them on release day.
Now it only hold sources, so as long as the sources are up to date, there is no point running ./tools/update.sh when testing hybrid.