### PR TITLE
Cleanup test_force bundle/package naming.

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -178,7 +178,7 @@ module.exports = {
             longDescription: 'A string in reverse internet domain format that identifies your app\'s package or bundle. For example, "com.mycompany.myapp".',
             prompt: 'Enter your package name:',
             error: cli => val => '\'' + val + '\' is not a valid package name.',
-            validate: cli => val => /^[a-z]+[a-z0-9_]*(\.[a-z]+[a-z0-9_]*)*$/.test(val),
+            validate: cli => val => /^[a-z]+[a-z0-9_]*(\.[a-z]+[a-z0-9_-]*)*$/.test(val),
             type: 'string'
         },
         organization: {

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -272,13 +272,13 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
     utils.runProcessThrowError(path.join('tools', 'update.sh') + ' -b ' + sdkBranch + ' -o ' + os, pluginRepoDir);
 }
 
-function cleanName(name, delimiter) {
-    return name.replace(/[#_\.]/g, delimiter);
+function cleanName(name) {
+    return name.replace(/[#_\.]/g, '_');
 }
 
-function templateCleanName(name, delimiter) {
+function templateCleanName(name) {
     // remove trailing tag/branch, then change camel case to delimiter separated.
-    return cleanSplit(name, '#')[0].replace(/([A-Z])/g, delimiter + "$1").slice(1).toLowerCase();
+    return cleanSplit(name, '#')[0].replace(/([A-Z])/g, "_$1").slice(1).toLowerCase();
 }
 
 //
@@ -299,8 +299,7 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
         templateRepoUri = null;
     }
     var target = actualAppType + ' app for ' + os + (templateRepoUri ? ' based on template ' + templateName : '');
-    var delimiter = (os === OS.ios) ? '_' : '_';
-    var appName = (templateRepoUri ? templateCleanName(templateName, delimiter) : cleanName(actualAppType, delimiter));
+    var appName = (templateRepoUri ? templateCleanName(templateName) : cleanName(actualAppType));
     // "native" is an illegal word for android package
     if (os === OS.android && appName === 'native') {
         appName = 'native_java'

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -302,9 +302,8 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
     var appName = (templateRepoUri ? templateCleanName(templateName) : cleanName(actualAppType));
     // "native" is an illegal word for android package
     if (os === OS.android && appName === 'native') {
-        appName = 'native_java'
+        appName = 'native_java';
     }
-
     var outputDir = path.join(tmpDir, appName);
     var forcecli = (isReactNative
                     ? SDK.forceclis.forcereact
@@ -319,7 +318,7 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
 
     var packageName = (os === OS.ios && !isHybrid) ? 'com.salesforce' : 'com.salesforce.' + appName;
     if (os === OS.ios && !isHybrid) {
-        packageName = packageName.replace(/[_]/g, '-')
+        packageName = packageName.replace(/[_]/g, '-');
     }
 
     var execPath = useSfdxRequested

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -272,8 +272,13 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
     utils.runProcessThrowError(path.join('tools', 'update.sh') + ' -b ' + sdkBranch + ' -o ' + os, pluginRepoDir);
 }
 
-function cleanName(name) {
-    return name.replace(/[#-\.]/g, '_')
+function cleanName(name, delimiter) {
+    return name.replace(/[#_\.]/g, delimiter);
+}
+
+function templateCleanName(name, delimiter) {
+    // remove trailing tag/branch, then change camel case to delimiter separated.
+    return cleanSplit(name, '#')[0].replace(/([A-Z])/g, delimiter + "$1").slice(1).toLowerCase();
 }
 
 //
@@ -294,14 +299,13 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
         templateRepoUri = null;
     }
     var target = actualAppType + ' app for ' + os + (templateRepoUri ? ' based on template ' + templateName : '');
-    var appName = 'App_' + (templateRepoUri ? cleanName(templateName) : actualAppType) + '_' + os;
-    // Add app type unless the app is native or react native iOS
-    var packageSuffix = (os === OS.ios && !isHybrid) ? '' : '.' + actualAppType;
+    var delimiter = (os === OS.ios) ? '_' : '_';
+    var appName = (templateRepoUri ? templateCleanName(templateName, delimiter) : cleanName(actualAppType, delimiter));
     // "native" is an illegal word for android package
-    if (actualAppType === APP_TYPE.native) {
-        packageSuffix = packageSuffix.replace('native', 'native_java');
+    if (os === OS.android && appName === 'native') {
+        appName = 'native_java'
     }
-    var packageName = 'com.salesforce' + packageSuffix;
+
     var outputDir = path.join(tmpDir, appName);
     var forcecli = (isReactNative
                     ? SDK.forceclis.forcereact
@@ -313,6 +317,11 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
                          )
                       )
                    );
+
+    var packageName = (os === OS.ios && !isHybrid) ? 'com.salesforce' : 'com.salesforce.' + appName;
+    if (os === OS.ios && !isHybrid) {
+        packageName = packageName.replace(/[_]/g, '-')
+    }
 
     var execPath = useSfdxRequested
         ? 'sfdx mobilesdk:' + forcecli.topic + ':'


### PR DESCRIPTION
All iOS bundles now use dash (except hybrid because cordova errors) and all Android packages use underscores.  Templates are parsed out by word and use dash or underscore based on os.  The prefixed "App_" and postfixed "_ios/_android/_dev" have been removed from app name and bundle/package strings.  