### PR TITLE
Simplifying generated app's name and package generation

### DIFF
--- a/release/setup_test_branches.js
+++ b/release/setup_test_branches.js
@@ -177,7 +177,8 @@ async function prepareRepo(repo, params) {
                     {
                         msg: `Setting up ${config.testMasterBranch}`,
                         cmds: [
-                            createBranch(config.testMasterBranch, 'master') // not fixing submodules / package.json files so it's doesn't conflict on merge
+                            createBranch(config.testMasterBranch, 'master'), // not fixing submodules / package.json files so it's doesn't conflict on merge
+                            params.noDev && params.filesWithOrg ? pointToFork(config.testMasterBranch, params) : null
                         ]
                     },
                     !params.hasDoc ? null : createBranch(config.testDocBranch, 'gh-pages'),

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -289,7 +289,7 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
     }
     var target = computeTargetDescription(os, actualAppType, templateRepoUri);
     var appName = computeAppName(os, actualAppType, templateRepoUri);
-    var packageName = computePackageName(appName);
+    var packageName = computePackageName(os, actualAppType, appName);
 
     var outputDir = path.join(tmpDir, appName);
     var forcecli = (isReactNative
@@ -506,7 +506,8 @@ function computeTargetDescription(os, actualAppType, templateRepoUri) {
 //
 // Compute app package
 //
-function computePackageName(appName) {
-    return 'com.salesforce.' + appName
+function computePackageName(os, actualAppType, appName) {
+    var isHybrid = actualAppType === APP_TYPE.hybrid_local || actualAppType === APP_TYPE.hybrid_remote;
+    return 'com.salesforce' + (os === OS.ios && !isHybrid ? '' : '.' + appName);
 }
     


### PR DESCRIPTION
Also with the last PR, it was no longer possible to do `test_force.js --cli=forcehybrid`, because the generated app for iOS and Android would be named the same, and so the second one would throw an error