### PR TITLE
Changing supported cocoapod version to 1.8-1.9.1 

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -48,8 +48,8 @@ module.exports = {
         },
         pod: {
             checkCmd: 'pod --version',
-            minVersion: '1.7.2',
-            maxVersion: '1.9'
+            minVersion: '1.8',
+            maxVersion: '1.9.1'
         },
         cordova: {
             checkCmd: 'cordova -v',

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -48,7 +48,7 @@ module.exports = {
         },
         pod: {
             checkCmd: 'pod --version',
-            minVersion: '1.8',
+            minVersion: '1.7.2',
             maxVersion: '1.9.1'
         },
         cordova: {


### PR DESCRIPTION
Before it was 1.7.2-1.9.

Successfully generated and compiled iOS apps with test_force.js