### PR TITLE
New apptype for forcehybrid: hybrid_lwc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,542 @@
-[![CircleCI](https://circleci.com/gh/forcedotcom/SalesforceMobileSDK-Package/tree/dev.svg?style=svg)](https://circleci.com/gh/forcedotcom/SalesforceMobileSDK-Package/tree/dev)
+# sfdx-mobilesdk-plugin 
 
-# SalesforceMobileSDK-Package
-Repo for forceios/forcedroid/forcehybrid/forcereact and the sfdx plugin.
+A plugin for the Salesforce CLI to create mobile applications to interface with the [Salesforce Platform](http://www.salesforce.com/platform/overview/), leveraging the [Salesforce Mobile SDK for iOS](https://github.com/forcedotcom/SalesforceMobileSDK-iOS) and the [Salesforce Mobile SDK for Android](https://github.com/forcedotcom/SalesforceMobileSDK-Android) repos.
 
-## To get started do the following from the root directory
-``` shell
-node ./install.js
+## Special Note Regarding SFDX and Oclif
+
+SFDX now supports the Heroku "O"pen "CLI" "F"ramework and sfdx-mobilesdk-plugin v7.1.0 has been updated to be compatible. The new plugin will run in both version 6 and version 7 instances of the SFDX cli. However, older versions of the mobilesdk plugin will not work in the Oclif version of the CLI. 
+
+If there is a need to use an older plugin one must first uninstall V7 of the CLI and install a V6 instance.
+
+To determine the latest version of v6 go here:
+
+https://www.npmjs.com/package/sfdx-cli?activeTab=versions
+
+The most reliable way to install a previous version of the CLI is via npm.
+
+`npm install sfdx-cli@<V6 version from npmjs> -g`
+
+## Setup
+
+### Install from source
+
+1. Install the SDFX CLI (https://developer.salesforce.com/tools/sfdxcli).
+
+2. Clone the repository: `git clone git@github.com:forcedotcom/SalesforceMobileSDK-Package`
+
+3. Install npm modules: `npm install`
+
+4. Generate oclif command classes `./sfdx/generate_oclif.js`
+
+5. Link the plugin: `sfdx plugins:link sfdx`
+
+### Install as plugin
+
+1. Install plugin: `sfdx plugins:install sfdx-mobilesdk-plugin`
+
+## Help
+```
+-> sfdx mobilesdk --help
+create mobile apps based on the Salesforce Mobile SDK
+
+USAGE
+  $ sfdx mobilesdk:COMMAND
+
+TOPICS
+  mobilesdk:android      create an Android native mobile application
+  mobilesdk:hybrid       create a hybrid mobile application
+  mobilesdk:ios          create an iOS native mobile application
+  mobilesdk:reactnative  create a React Native mobile application
+
 ```
 
-## To run forceios do
-```shell
-./ios/forceios.js
+## Create a native iOS application 
+### Help for iOS
+```
+-> sfdx mobilesdk:ios --help
+create an iOS native mobile application
+
+USAGE
+  $ sfdx mobilesdk:ios:COMMAND
+
+COMMANDS
+  mobilesdk:ios:checkconfig         validate store or syncs configuration
+  mobilesdk:ios:create              create an iOS native mobile application
+  mobilesdk:ios:createwithtemplate  create an iOS native mobile application from
+                                    a template
+  mobilesdk:ios:listtemplates       list available Mobile SDK templates to
+                                    create an iOS native mobile application
+  mobilesdk:ios:version             show version of Mobile SDK
+
 ```
 
-## To run forcedroid do
-```shell
-./android/forcedroid.js
+### Create Objective-C (native) or Swift (native_swift) application
+```
+-> sfdx mobilesdk:ios:create --help
+create an iOS native mobile application
+
+USAGE
+  $ sfdx mobilesdk:ios:create
+
+OPTIONS
+  -d, --outputdir=outputdir        output directory (leave empty for current
+                                   directory)
+
+  -k, --packagename=packagename    (required) app package identifier (e.g.
+                                   com.mycompany.myapp)
+
+  -n, --appname=appname            (required) application name
+
+  -o, --organization=organization  (required) organization name (your
+                                   company's/organization's name)
+
+  -t, --apptype=apptype            application type (native_swift or native,
+                                   leave empty for native_swift)
+
+DESCRIPTION
+  This command initiates creation of a new app based on the standard Mobile SDK 
+  template.
+
 ```
 
-## To run forcehybrid do
-```shell
-./hybrid/forcehybrid.js
+### List available native iOS templates
+```
+-> sfdx mobilesdk:ios:listtemplates --help
+list available Mobile SDK templates to create an iOS native mobile application
+
+USAGE
+  $ sfdx mobilesdk:ios:listtemplates
+
+DESCRIPTION
+  This command displays the list of available Mobile SDK templates. You can copy 
+  repo paths from the output for use with the createwithtemplate command.
+
 ```
 
-## To run forcereact do
-```shell
-./react/forcereact.js
+### Create iOS application from template
+```
+-> sfdx mobilesdk:ios:createwithtemplate --help
+create an iOS native mobile application from a template
+
+USAGE
+  $ sfdx mobilesdk:ios:createwithtemplate
+
+OPTIONS
+  -d, --outputdir=outputdir              output directory (leave empty for
+                                         current directory)
+
+  -k, --packagename=packagename          (required) app package identifier (e.g.
+                                         com.mycompany.myapp)
+
+  -n, --appname=appname                  (required) application name
+
+  -o, --organization=organization        (required) organization name (your
+                                         company's/organization's name)
+
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
+
+DESCRIPTION
+  This command initiates creation of a new app based on the Mobile SDK template 
+  that you specify. The template can be a specialized app for your app type that 
+  Mobile SDK provides, or your own custom app that you've configured to use as a 
+  template. See 
+  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
+  os_new_project_template.htm for information on custom templates.
+
 ```
 
-## To load the sfdx plugin from source do
-```shell
-sfdx plugins:link sfdx
+### Check store or syncs config
+```
+-> sfdx mobilesdk:ios:checkconfig --help
+validate store or syncs configuration
+
+USAGE
+  $ sfdx mobilesdk:ios:checkconfig
+
+OPTIONS
+  -p, --configpath=configpath  (required) path to store or syncs config to
+                               validate
+
+  -t, --configtype=configtype  (required) type of config to validate (store or
+                               syncs)
+
+DESCRIPTION
+  This command checks whether the given store or syncs configuration is valid 
+  according to its JSON schema.
+
 ```
 
-## To run the sfdx plugin do
-```shell
-sfdx mobilesdk:ios --help 
-sfdx mobilesdk:android --help 
-sfdx mobilesdk:hybrid --help 
-sfdx mobilesdk:reactnative --help
+## Create a native Android application 
+### Help for Android
+```
+-> sfdx mobilesdk:android --help
+create an Android native mobile application
+
+USAGE
+  $ sfdx mobilesdk:android:COMMAND
+
+COMMANDS
+  mobilesdk:android:checkconfig         validate store or syncs configuration
+  mobilesdk:android:create              create an Android native mobile
+                                        application
+  mobilesdk:android:createwithtemplate  create an Android native mobile
+                                        application from a template
+  mobilesdk:android:listtemplates       list available Mobile SDK templates to
+                                        create an Android native mobile
+                                        application
+  mobilesdk:android:version             show version of Mobile SDK
+
 ```
 
-## To test forceios, forcedroid, forcehybrid, forcereact or the sfdx plugin do
-```shell
-./test/test_force.js
+### Create Java (native) or Kotlin (native_kotlin) application
+```
+-> sfdx mobilesdk:android:create --help
+create an Android native mobile application
+
+USAGE
+  $ sfdx mobilesdk:android:create
+
+OPTIONS
+  -d, --outputdir=outputdir        output directory (leave empty for current
+                                   directory)
+
+  -k, --packagename=packagename    (required) app package identifier (e.g.
+                                   com.mycompany.myapp)
+
+  -n, --appname=appname            (required) application name
+
+  -o, --organization=organization  (required) organization name (your
+                                   company's/organization's name)
+
+  -t, --apptype=apptype            application type (native_kotlin or native,
+                                   leave empty for native_kotlin)
+
+DESCRIPTION
+  This command initiates creation of a new app based on the standard Mobile SDK 
+  template.
+
 ```
 
-## To npm pack forceios, forcedroid, forcehybrid, forcereact or the sfx plugin do
-```shell
-./pack/pack.js
+### List available native Android templates
+```
+-> sfdx mobilesdk:android:listtemplates --help
+list available Mobile SDK templates to create an Android native mobile application
+
+USAGE
+  $ sfdx mobilesdk:android:listtemplates
+
+DESCRIPTION
+  This command displays the list of available Mobile SDK templates. You can copy 
+  repo paths from the output for use with the createwithtemplate command.
+
 ```
 
-## To do a full release
+### Create Android application from template
 ```
-./release/release.js
+-> sfdx mobilesdk:android:createwithtemplate --help
+create an Android native mobile application from a template
+
+USAGE
+  $ sfdx mobilesdk:android:createwithtemplate
+
+OPTIONS
+  -d, --outputdir=outputdir              output directory (leave empty for
+                                         current directory)
+
+  -k, --packagename=packagename          (required) app package identifier (e.g.
+                                         com.mycompany.myapp)
+
+  -n, --appname=appname                  (required) application name
+
+  -o, --organization=organization        (required) organization name (your
+                                         company's/organization's name)
+
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
+
+DESCRIPTION
+  This command initiates creation of a new app based on the Mobile SDK template 
+  that you specify. The template can be a specialized app for your app type that 
+  Mobile SDK provides, or your own custom app that you've configured to use as a 
+  template. See 
+  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
+  os_new_project_template.htm for information on custom templates.
+
 ```
+
+### Check store or syncs config
+```
+-> sfdx mobilesdk:android:checkconfig --help
+validate store or syncs configuration
+
+USAGE
+  $ sfdx mobilesdk:android:checkconfig
+
+OPTIONS
+  -p, --configpath=configpath  (required) path to store or syncs config to
+                               validate
+
+  -t, --configtype=configtype  (required) type of config to validate (store or
+                               syncs)
+
+DESCRIPTION
+  This command checks whether the given store or syncs configuration is valid 
+  according to its JSON schema.
+
+```
+
+## Create an hybrid application 
+### Help for hybrid
+```
+-> sfdx mobilesdk:hybrid --help
+create a hybrid mobile application
+
+USAGE
+  $ sfdx mobilesdk:hybrid:COMMAND
+
+COMMANDS
+  mobilesdk:hybrid:checkconfig         validate store or syncs configuration
+  mobilesdk:hybrid:create              create a hybrid mobile application
+  mobilesdk:hybrid:createwithtemplate  create a hybrid mobile application from a
+                                       template
+  mobilesdk:hybrid:listtemplates       list available Mobile SDK templates to
+                                       create a hybrid mobile application
+  mobilesdk:hybrid:version             show version of Mobile SDK
+
+```
+
+### Create hybrid application
+```
+-> sfdx mobilesdk:hybrid:create --help
+create a hybrid mobile application
+
+USAGE
+  $ sfdx mobilesdk:hybrid:create
+
+OPTIONS
+  -d, --outputdir=outputdir        output directory (leave empty for current
+                                   directory)
+
+  -k, --packagename=packagename    (required) app package identifier (e.g.
+                                   com.mycompany.myapp)
+
+  -n, --appname=appname            (required) application name
+
+  -o, --organization=organization  (required) organization name (your
+                                   company's/organization's name)
+
+  -p, --platform=platform          (required) comma-separated list of platforms
+                                   (ios, android)
+
+  -s, --startpage=startpage        app start page (the start page of your remote
+                                   app; required for hybrid_remote apps only)
+
+  -t, --apptype=apptype            application type (hybrid_local or
+                                   hybrid_remote or hybrid_lwc, leave empty for
+                                   hybrid_local)
+
+DESCRIPTION
+  This command initiates creation of a new app based on the standard Mobile SDK 
+  template.
+
+```
+
+### List available hybrid templates
+```
+-> sfdx mobilesdk:hybrid:listtemplates --help
+list available Mobile SDK templates to create a hybrid mobile application
+
+USAGE
+  $ sfdx mobilesdk:hybrid:listtemplates
+
+DESCRIPTION
+  This command displays the list of available Mobile SDK templates. You can copy 
+  repo paths from the output for use with the createwithtemplate command.
+
+```
+
+### Create hybrid application from template
+```
+-> sfdx mobilesdk:hybrid:createwithtemplate --help
+create a hybrid mobile application from a template
+
+USAGE
+  $ sfdx mobilesdk:hybrid:createwithtemplate
+
+OPTIONS
+  -d, --outputdir=outputdir              output directory (leave empty for
+                                         current directory)
+
+  -k, --packagename=packagename          (required) app package identifier (e.g.
+                                         com.mycompany.myapp)
+
+  -n, --appname=appname                  (required) application name
+
+  -o, --organization=organization        (required) organization name (your
+                                         company's/organization's name)
+
+  -p, --platform=platform                (required) comma-separated list of
+                                         platforms (ios, android)
+
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
+
+  -s, --startpage=startpage              app start page (the start page of your
+                                         remote app; required for hybrid_remote
+                                         apps only)
+
+DESCRIPTION
+  This command initiates creation of a new app based on the Mobile SDK template 
+  that you specify. The template can be a specialized app for your app type that 
+  Mobile SDK provides, or your own custom app that you've configured to use as a 
+  template. See 
+  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
+  os_new_project_template.htm for information on custom templates.
+
+```
+
+### Check store or syncs config
+```
+-> sfdx mobilesdk:hybrid:checkconfig --help
+validate store or syncs configuration
+
+USAGE
+  $ sfdx mobilesdk:hybrid:checkconfig
+
+OPTIONS
+  -p, --configpath=configpath  (required) path to store or syncs config to
+                               validate
+
+  -t, --configtype=configtype  (required) type of config to validate (store or
+                               syncs)
+
+DESCRIPTION
+  This command checks whether the given store or syncs configuration is valid 
+  according to its JSON schema.
+
+```
+
+## Create a React Native application
+### Help for React Native
+```
+-> sfdx mobilesdk:reactnative --help
+create a React Native mobile application
+
+USAGE
+  $ sfdx mobilesdk:reactnative:COMMAND
+
+COMMANDS
+  mobilesdk:reactnative:checkconfig         validate store or syncs
+                                            configuration
+  mobilesdk:reactnative:create              create a React Native mobile
+                                            application
+  mobilesdk:reactnative:createwithtemplate  create a React Native mobile
+                                            application from a template
+  mobilesdk:reactnative:listtemplates       list available Mobile SDK templates
+                                            to create a React Native mobile
+                                            application
+  mobilesdk:reactnative:version             show version of Mobile SDK
+
+```
+
+### Create React Native application
+```
+-> sfdx mobilesdk:reactnative:create --help
+create a React Native mobile application
+
+USAGE
+  $ sfdx mobilesdk:reactnative:create
+
+OPTIONS
+  -d, --outputdir=outputdir        output directory (leave empty for current
+                                   directory)
+
+  -k, --packagename=packagename    (required) app package identifier (e.g.
+                                   com.mycompany.myapp)
+
+  -n, --appname=appname            (required) application name
+
+  -o, --organization=organization  (required) organization name (your
+                                   company's/organization's name)
+
+  -p, --platform=platform          (required) comma-separated list of platforms
+                                   (ios, android)
+
+DESCRIPTION
+  This command initiates creation of a new app based on the standard Mobile SDK 
+  template.
+
+```
+
+### List available React Native templates
+```
+-> sfdx mobilesdk:reactnative:listtemplates --help
+list available Mobile SDK templates to create a React Native mobile application
+
+USAGE
+  $ sfdx mobilesdk:reactnative:listtemplates
+
+DESCRIPTION
+  This command displays the list of available Mobile SDK templates. You can copy 
+  repo paths from the output for use with the createwithtemplate command.
+
+```
+
+### Create React Native application from template
+```
+-> sfdx mobilesdk:reactnative:createwithtemplate --help
+create a React Native mobile application from a template
+
+USAGE
+  $ sfdx mobilesdk:reactnative:createwithtemplate
+
+OPTIONS
+  -d, --outputdir=outputdir              output directory (leave empty for
+                                         current directory)
+
+  -k, --packagename=packagename          (required) app package identifier (e.g.
+                                         com.mycompany.myapp)
+
+  -n, --appname=appname                  (required) application name
+
+  -o, --organization=organization        (required) organization name (your
+                                         company's/organization's name)
+
+  -p, --platform=platform                (required) comma-separated list of
+                                         platforms (ios, android)
+
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
+
+DESCRIPTION
+  This command initiates creation of a new app based on the Mobile SDK template 
+  that you specify. The template can be a specialized app for your app type that 
+  Mobile SDK provides, or your own custom app that you've configured to use as a 
+  template. See 
+  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
+  os_new_project_template.htm for information on custom templates.
+
+```
+
+### Check store or syncs config
+```
+-> sfdx mobilesdk:reactnative:checkconfig --help
+validate store or syncs configuration
+
+USAGE
+  $ sfdx mobilesdk:reactnative:checkconfig
+
+OPTIONS
+  -p, --configpath=configpath  (required) path to store or syncs config to
+                               validate
+
+  -t, --configtype=configtype  (required) type of config to validate (store or
+                               syncs)
+
+DESCRIPTION
+  This command checks whether the given store or syncs configuration is valid 
+  according to its JSON schema.
+
+```
+

--- a/README.md
+++ b/README.md
@@ -1,542 +1,57 @@
-# sfdx-mobilesdk-plugin 
+[![CircleCI](https://circleci.com/gh/forcedotcom/SalesforceMobileSDK-Package/tree/dev.svg?style=svg)](https://circleci.com/gh/forcedotcom/SalesforceMobileSDK-Package/tree/dev)
 
-A plugin for the Salesforce CLI to create mobile applications to interface with the [Salesforce Platform](http://www.salesforce.com/platform/overview/), leveraging the [Salesforce Mobile SDK for iOS](https://github.com/forcedotcom/SalesforceMobileSDK-iOS) and the [Salesforce Mobile SDK for Android](https://github.com/forcedotcom/SalesforceMobileSDK-Android) repos.
+# SalesforceMobileSDK-Package
+Repo for forceios/forcedroid/forcehybrid/forcereact and the sfdx plugin.
 
-## Special Note Regarding SFDX and Oclif
-
-SFDX now supports the Heroku "O"pen "CLI" "F"ramework and sfdx-mobilesdk-plugin v7.1.0 has been updated to be compatible. The new plugin will run in both version 6 and version 7 instances of the SFDX cli. However, older versions of the mobilesdk plugin will not work in the Oclif version of the CLI. 
-
-If there is a need to use an older plugin one must first uninstall V7 of the CLI and install a V6 instance.
-
-To determine the latest version of v6 go here:
-
-https://www.npmjs.com/package/sfdx-cli?activeTab=versions
-
-The most reliable way to install a previous version of the CLI is via npm.
-
-`npm install sfdx-cli@<V6 version from npmjs> -g`
-
-## Setup
-
-### Install from source
-
-1. Install the SDFX CLI (https://developer.salesforce.com/tools/sfdxcli).
-
-2. Clone the repository: `git clone git@github.com:forcedotcom/SalesforceMobileSDK-Package`
-
-3. Install npm modules: `npm install`
-
-4. Generate oclif command classes `./sfdx/generate_oclif.js`
-
-5. Link the plugin: `sfdx plugins:link sfdx`
-
-### Install as plugin
-
-1. Install plugin: `sfdx plugins:install sfdx-mobilesdk-plugin`
-
-## Help
-```
--> sfdx mobilesdk --help
-create mobile apps based on the Salesforce Mobile SDK
-
-USAGE
-  $ sfdx mobilesdk:COMMAND
-
-TOPICS
-  mobilesdk:android      create an Android native mobile application
-  mobilesdk:hybrid       create a hybrid mobile application
-  mobilesdk:ios          create an iOS native mobile application
-  mobilesdk:reactnative  create a React Native mobile application
-
+## To get started do the following from the root directory
+``` shell
+node ./install.js
 ```
 
-## Create a native iOS application 
-### Help for iOS
-```
--> sfdx mobilesdk:ios --help
-create an iOS native mobile application
-
-USAGE
-  $ sfdx mobilesdk:ios:COMMAND
-
-COMMANDS
-  mobilesdk:ios:checkconfig         validate store or syncs configuration
-  mobilesdk:ios:create              create an iOS native mobile application
-  mobilesdk:ios:createwithtemplate  create an iOS native mobile application from
-                                    a template
-  mobilesdk:ios:listtemplates       list available Mobile SDK templates to
-                                    create an iOS native mobile application
-  mobilesdk:ios:version             show version of Mobile SDK
-
+## To run forceios do
+```shell
+./ios/forceios.js
 ```
 
-### Create Objective-C (native) or Swift (native_swift) application
-```
--> sfdx mobilesdk:ios:create --help
-create an iOS native mobile application
-
-USAGE
-  $ sfdx mobilesdk:ios:create
-
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -t, --apptype=apptype            application type (native_swift or native,
-                                   leave empty for native_swift)
-
-DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
-  template.
-
+## To run forcedroid do
+```shell
+./android/forcedroid.js
 ```
 
-### List available native iOS templates
-```
--> sfdx mobilesdk:ios:listtemplates --help
-list available Mobile SDK templates to create an iOS native mobile application
-
-USAGE
-  $ sfdx mobilesdk:ios:listtemplates
-
-DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
-  repo paths from the output for use with the createwithtemplate command.
-
+## To run forcehybrid do
+```shell
+./hybrid/forcehybrid.js
 ```
 
-### Create iOS application from template
-```
--> sfdx mobilesdk:ios:createwithtemplate --help
-create an iOS native mobile application from a template
-
-USAGE
-  $ sfdx mobilesdk:ios:createwithtemplate
-
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
-
-DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
-
+## To run forcereact do
+```shell
+./react/forcereact.js
 ```
 
-### Check store or syncs config
-```
--> sfdx mobilesdk:ios:checkconfig --help
-validate store or syncs configuration
-
-USAGE
-  $ sfdx mobilesdk:ios:checkconfig
-
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
-
-DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
-  according to its JSON schema.
-
+## To load the sfdx plugin from source do
+```shell
+sfdx plugins:link sfdx
 ```
 
-## Create a native Android application 
-### Help for Android
-```
--> sfdx mobilesdk:android --help
-create an Android native mobile application
-
-USAGE
-  $ sfdx mobilesdk:android:COMMAND
-
-COMMANDS
-  mobilesdk:android:checkconfig         validate store or syncs configuration
-  mobilesdk:android:create              create an Android native mobile
-                                        application
-  mobilesdk:android:createwithtemplate  create an Android native mobile
-                                        application from a template
-  mobilesdk:android:listtemplates       list available Mobile SDK templates to
-                                        create an Android native mobile
-                                        application
-  mobilesdk:android:version             show version of Mobile SDK
-
+## To run the sfdx plugin do
+```shell
+sfdx mobilesdk:ios --help 
+sfdx mobilesdk:android --help 
+sfdx mobilesdk:hybrid --help 
+sfdx mobilesdk:reactnative --help
 ```
 
-### Create Java (native) or Kotlin (native_kotlin) application
-```
--> sfdx mobilesdk:android:create --help
-create an Android native mobile application
-
-USAGE
-  $ sfdx mobilesdk:android:create
-
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -t, --apptype=apptype            application type (native_kotlin or native,
-                                   leave empty for native_kotlin)
-
-DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
-  template.
-
+## To test forceios, forcedroid, forcehybrid, forcereact or the sfdx plugin do
+```shell
+./test/test_force.js
 ```
 
-### List available native Android templates
-```
--> sfdx mobilesdk:android:listtemplates --help
-list available Mobile SDK templates to create an Android native mobile application
-
-USAGE
-  $ sfdx mobilesdk:android:listtemplates
-
-DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
-  repo paths from the output for use with the createwithtemplate command.
-
+## To npm pack forceios, forcedroid, forcehybrid, forcereact or the sfx plugin do
+```shell
+./pack/pack.js
 ```
 
-### Create Android application from template
+## To do a full release
 ```
--> sfdx mobilesdk:android:createwithtemplate --help
-create an Android native mobile application from a template
-
-USAGE
-  $ sfdx mobilesdk:android:createwithtemplate
-
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
-
-DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
-
+./release/release.js
 ```
-
-### Check store or syncs config
-```
--> sfdx mobilesdk:android:checkconfig --help
-validate store or syncs configuration
-
-USAGE
-  $ sfdx mobilesdk:android:checkconfig
-
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
-
-DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
-  according to its JSON schema.
-
-```
-
-## Create an hybrid application 
-### Help for hybrid
-```
--> sfdx mobilesdk:hybrid --help
-create a hybrid mobile application
-
-USAGE
-  $ sfdx mobilesdk:hybrid:COMMAND
-
-COMMANDS
-  mobilesdk:hybrid:checkconfig         validate store or syncs configuration
-  mobilesdk:hybrid:create              create a hybrid mobile application
-  mobilesdk:hybrid:createwithtemplate  create a hybrid mobile application from a
-                                       template
-  mobilesdk:hybrid:listtemplates       list available Mobile SDK templates to
-                                       create a hybrid mobile application
-  mobilesdk:hybrid:version             show version of Mobile SDK
-
-```
-
-### Create hybrid application
-```
--> sfdx mobilesdk:hybrid:create --help
-create a hybrid mobile application
-
-USAGE
-  $ sfdx mobilesdk:hybrid:create
-
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -p, --platform=platform          (required) comma-separated list of platforms
-                                   (ios, android)
-
-  -s, --startpage=startpage        app start page (the start page of your remote
-                                   app; required for hybrid_remote apps only)
-
-  -t, --apptype=apptype            application type (hybrid_local or
-                                   hybrid_remote or hybrid_lwc, leave empty for
-                                   hybrid_local)
-
-DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
-  template.
-
-```
-
-### List available hybrid templates
-```
--> sfdx mobilesdk:hybrid:listtemplates --help
-list available Mobile SDK templates to create a hybrid mobile application
-
-USAGE
-  $ sfdx mobilesdk:hybrid:listtemplates
-
-DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
-  repo paths from the output for use with the createwithtemplate command.
-
-```
-
-### Create hybrid application from template
-```
--> sfdx mobilesdk:hybrid:createwithtemplate --help
-create a hybrid mobile application from a template
-
-USAGE
-  $ sfdx mobilesdk:hybrid:createwithtemplate
-
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -p, --platform=platform                (required) comma-separated list of
-                                         platforms (ios, android)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
-
-  -s, --startpage=startpage              app start page (the start page of your
-                                         remote app; required for hybrid_remote
-                                         apps only)
-
-DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
-
-```
-
-### Check store or syncs config
-```
--> sfdx mobilesdk:hybrid:checkconfig --help
-validate store or syncs configuration
-
-USAGE
-  $ sfdx mobilesdk:hybrid:checkconfig
-
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
-
-DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
-  according to its JSON schema.
-
-```
-
-## Create a React Native application
-### Help for React Native
-```
--> sfdx mobilesdk:reactnative --help
-create a React Native mobile application
-
-USAGE
-  $ sfdx mobilesdk:reactnative:COMMAND
-
-COMMANDS
-  mobilesdk:reactnative:checkconfig         validate store or syncs
-                                            configuration
-  mobilesdk:reactnative:create              create a React Native mobile
-                                            application
-  mobilesdk:reactnative:createwithtemplate  create a React Native mobile
-                                            application from a template
-  mobilesdk:reactnative:listtemplates       list available Mobile SDK templates
-                                            to create a React Native mobile
-                                            application
-  mobilesdk:reactnative:version             show version of Mobile SDK
-
-```
-
-### Create React Native application
-```
--> sfdx mobilesdk:reactnative:create --help
-create a React Native mobile application
-
-USAGE
-  $ sfdx mobilesdk:reactnative:create
-
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -p, --platform=platform          (required) comma-separated list of platforms
-                                   (ios, android)
-
-DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
-  template.
-
-```
-
-### List available React Native templates
-```
--> sfdx mobilesdk:reactnative:listtemplates --help
-list available Mobile SDK templates to create a React Native mobile application
-
-USAGE
-  $ sfdx mobilesdk:reactnative:listtemplates
-
-DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
-  repo paths from the output for use with the createwithtemplate command.
-
-```
-
-### Create React Native application from template
-```
--> sfdx mobilesdk:reactnative:createwithtemplate --help
-create a React Native mobile application from a template
-
-USAGE
-  $ sfdx mobilesdk:reactnative:createwithtemplate
-
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -p, --platform=platform                (required) comma-separated list of
-                                         platforms (ios, android)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
-
-DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
-
-```
-
-### Check store or syncs config
-```
--> sfdx mobilesdk:reactnative:checkconfig --help
-validate store or syncs configuration
-
-USAGE
-  $ sfdx mobilesdk:reactnative:checkconfig
-
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
-
-DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
-  according to its JSON schema.
-
-```
-

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -42,12 +42,7 @@ create mobile apps based on the Salesforce Mobile SDK
 USAGE
   $ sfdx mobilesdk:COMMAND
 
-COMMANDS
-
-
 TOPICS
-  Run help for each topic below to view subcommands
-
   mobilesdk:android      create an Android native mobile application
   mobilesdk:hybrid       create a hybrid mobile application
   mobilesdk:ios          create an iOS native mobile application
@@ -138,7 +133,8 @@ OPTIONS
   -o, --organization=organization        (required) organization name (your
                                          company's/organization's name)
 
-  -r, --templaterepouri=templaterepouri  (required) template repo URI
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
 
 DESCRIPTION
   This command initiates creation of a new app based on the Mobile SDK template 
@@ -159,10 +155,10 @@ USAGE
   $ sfdx mobilesdk:ios:checkconfig
 
 OPTIONS
-  -c, --configpath=configpath  (required) path to store or syncs config to
+  -p, --configpath=configpath  (required) path to store or syncs config to
                                validate
 
-  -y, --configtype=configtype  (required) type of config to validate (store or
+  -t, --configtype=configtype  (required) type of config to validate (store or
                                syncs)
 
 DESCRIPTION
@@ -256,7 +252,8 @@ OPTIONS
   -o, --organization=organization        (required) organization name (your
                                          company's/organization's name)
 
-  -r, --templaterepouri=templaterepouri  (required) template repo URI
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
 
 DESCRIPTION
   This command initiates creation of a new app based on the Mobile SDK template 
@@ -277,10 +274,10 @@ USAGE
   $ sfdx mobilesdk:android:checkconfig
 
 OPTIONS
-  -c, --configpath=configpath  (required) path to store or syncs config to
+  -p, --configpath=configpath  (required) path to store or syncs config to
                                validate
 
-  -y, --configtype=configtype  (required) type of config to validate (store or
+  -t, --configtype=configtype  (required) type of config to validate (store or
                                syncs)
 
 DESCRIPTION
@@ -336,7 +333,8 @@ OPTIONS
                                    app; required for hybrid_remote apps only)
 
   -t, --apptype=apptype            application type (hybrid_local or
-                                   hybrid_remote, leave empty for hybrid_local)
+                                   hybrid_remote or hybrid_lwc, leave empty for
+                                   hybrid_local)
 
 DESCRIPTION
   This command initiates creation of a new app based on the standard Mobile SDK 
@@ -381,7 +379,8 @@ OPTIONS
   -p, --platform=platform                (required) comma-separated list of
                                          platforms (ios, android)
 
-  -r, --templaterepouri=templaterepouri  (required) template repo URI
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
 
   -s, --startpage=startpage              app start page (the start page of your
                                          remote app; required for hybrid_remote
@@ -406,10 +405,10 @@ USAGE
   $ sfdx mobilesdk:hybrid:checkconfig
 
 OPTIONS
-  -c, --configpath=configpath  (required) path to store or syncs config to
+  -p, --configpath=configpath  (required) path to store or syncs config to
                                validate
 
-  -y, --configtype=configtype  (required) type of config to validate (store or
+  -t, --configtype=configtype  (required) type of config to validate (store or
                                syncs)
 
 DESCRIPTION
@@ -507,7 +506,8 @@ OPTIONS
   -p, --platform=platform                (required) comma-separated list of
                                          platforms (ios, android)
 
-  -r, --templaterepouri=templaterepouri  (required) template repo URI
+  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
+                                         SDK template name
 
 DESCRIPTION
   This command initiates creation of a new app based on the Mobile SDK template 
@@ -528,10 +528,10 @@ USAGE
   $ sfdx mobilesdk:reactnative:checkconfig
 
 OPTIONS
-  -c, --configpath=configpath  (required) path to store or syncs config to
+  -p, --configpath=configpath  (required) path to store or syncs config to
                                validate
 
-  -y, --configtype=configtype  (required) type of config to validate (store or
+  -t, --configtype=configtype  (required) type of config to validate (store or
                                syncs)
 
 DESCRIPTION

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -107,10 +107,11 @@ module.exports = {
             dir: 'hybrid',
             platforms: ['ios', 'android'],
             toolNames: ['git', 'node', 'npm', 'cordova'],
-            appTypes: ['hybrid_local', 'hybrid_remote'],
+            appTypes: ['hybrid_local', 'hybrid_remote', 'hybrid_lwc'],
             appTypesToPath: {
                 'hybrid_local': 'HybridLocalTemplate',
-                'hybrid_remote': 'HybridRemoteTemplate'
+                'hybrid_remote': 'HybridRemoteTemplate',
+                'hybrid_lwc': 'HybridLwcTemplate'
             },
             commands: ['create', 'createwithtemplate', 'version', 'listtemplates', 'checkconfig']
         },

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -86,6 +86,27 @@ function createHybridApp(config) {
     // Cleanup
     utils.removeFile(path.join(webDir, 'template.js'));
 
+
+    // Create sfdx project if apptype is hybrid_lwc in a 'server' directory
+    if (config.apptype === 'hybrid_lwc') {
+        var serverDirName = 'server'
+        config.serverDir = path.join(config.projectDir, serverDirName)
+        utils.runProcessThrowError('sfdx force:project:create -n ' + serverDirName, config.projectDir);
+
+        // Copy cordova js to static resources
+        for (var platform of config.platform.split(',')) {
+            var cordovaStaticResourcesDir = path.join(config.serverDir, 'force-app', 'main', 'default', 'staticresources', 'cordova' + platform);
+            utils.mkDirIfNeeded(cordovaStaticResourcesDir);
+            utils.copyFile(path.join(config.projectDir, 'platforms', platform, 'platform_www', '*'), cordovaStaticResourcesDir);
+        }
+
+        // Merge server files from templates
+        utils.mergeFile(path.join(webDir, 'force-app'), path.join(config.serverDir, 'force-app'));
+
+        // Remove server files from www
+        utils.removeFile(path.join(webDir, 'force-app'));
+    }
+
     // Run cordova prepare
     utils.runProcessThrowError('cordova prepare', config.projectDir);
 

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -213,9 +213,18 @@ function printNextStepsForServerProjectIfNeeded(projectPath) {
         // Extra steps if there is a server project
     if (hasServerProject) {
         utils.logParagraph(['Your application also has a server project in ' + serverProjectPath + '.',
-                            'Make sure to deploy it to your org before running your application.'
+                            'Make sure to deploy it to your org before running your application.',
+                            '',
+                            'From ' + projectPath + ' do the following to setup a scratch org, push the server code:',
+                            '   - sfdx force:org:create -f server/config/project-scratch-def.json -a MyOrg',
+                            '   - cd server',
+                            '   - sfdx force:source:push -u MyOrg',
+                            'You also need a password to login to the scratch org from the mobile app:',
+                            '   - sfdx force:user:password:generate -u MyOrg'                            
                             ]);
     }
+
+
 }
 
 //

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -93,7 +93,7 @@ function createHybridApp(config) {
     // Create a fresh sfdx project
     // Add cordova js and plugins at static resources
     // Merge files from template into it
-    if (utils.dirExists(path.join(webDir, 'force-app'))) {
+    if (utils.dirExists(path.join(webDir, SERVER_PROJECT_DIR))) {
         config.serverDir = path.join(config.projectDir, SERVER_PROJECT_DIR)
         utils.runProcessThrowError('sfdx force:project:create -n ' + SERVER_PROJECT_DIR, config.projectDir);
 
@@ -105,10 +105,10 @@ function createHybridApp(config) {
         }
 
         // Merge server files from templates
-        utils.mergeFile(path.join(webDir, 'force-app'), path.join(config.serverDir, 'force-app'));
+        utils.mergeFile(path.join(webDir, SERVER_PROJECT_DIR), config.serverDir);
 
         // Remove server files from www
-        utils.removeFile(path.join(webDir, 'force-app'));
+        utils.removeFile(path.join(webDir, SERVER_PROJECT_DIR));
     }
 
     // Run cordova prepare

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -255,12 +255,17 @@ function replaceInFiles(from, to, files) {
  */
 function moveFile(from, to) {
     logDebug('Moving: ' + from + ' to ' + to);
-    var targetDir = path.parse(to).dir;
-    if (targetDir && !shelljs.test('-e', targetDir)) {
-        shelljs.mkdir('-p', targetDir);
-    }
+    shelljs.mkdir('-p', path.parse(to).dir);
     shelljs.mv(from, to);
 }
+
+/**
+ * Check there is a directory with given path
+ * @param {String} path of dir
+ */
+ function dirExists(path) {
+   return shelljs.test('-d', path);
+ }
 
 /**
  * Copy recursively.
@@ -284,7 +289,7 @@ function mergeFile(from, to) {
     logDebug('Merging: ' + from + ' to ' + to);
     shelljs.find(from).forEach(function(srcPath) {
         var relativePath = path.relative(from, srcPath)
-        if(fs.lstatSync(srcPath).isFile()) {
+        if(shelljs.test('-f', srcPath)) {
             shelljs.cp(path.join(from, relativePath), path.join(to, relativePath));
         } else {
             shelljs.mkdir('-p', path.join(to, relativePath));            
@@ -424,6 +429,7 @@ module.exports = {
     checkToolVersion,
     cloneRepo,
     copyFile,
+    dirExists,
     getVersionNumberFromString,
     log,
     logDebug,

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -257,7 +257,7 @@ function replaceInFiles(from, to, files) {
  */
 function moveFile(from, to) {
     logDebug('Moving: ' + from + ' to ' + to);
-    mkDirIfNeeded('-p', path.parse(to).dir);
+    mkDirIfNeeded(path.parse(to).dir);
     shelljs.mv(from, to);
 }
 

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -265,12 +265,31 @@ function moveFile(from, to) {
 /**
  * Copy recursively.
  *
- * @param {String} from Path of file or directory to move.
+ * @param {String} from Path of file or directory to copy.
  * @param {String} to New path for file or directory.
  */
 function copyFile(from, to) {
     logDebug('Copying: ' + from + ' to ' + to);
     shelljs.cp('-R', from, to);
+}
+
+/**
+ * Merge recursively. 
+ * Like copyFile except that it will merge into existing directories.
+ *
+ * @param {String} from Path of file or directory to move.
+ * @param {String} to New path for file or directory.
+ */
+function mergeFile(from, to) {
+    logDebug('Merging: ' + from + ' to ' + to);
+    shelljs.find(from).forEach(function(srcPath) {
+        var relativePath = path.relative(from, srcPath)
+        if(fs.lstatSync(srcPath).isFile()) {
+            shelljs.cp(path.join(from, relativePath), path.join(to, relativePath));
+        } else {
+            shelljs.mkdir('-p', path.join(to, relativePath));            
+        }
+    })
 }
 
 
@@ -411,6 +430,7 @@ module.exports = {
     logError,
     logInfo,
     logParagraph,
+    mergeFile,
     mkTmpDir,
     mkDirIfNeeded,
     moveFile,

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -229,7 +229,9 @@ function mkTmpDir() {
  * @param {string} Path of directory to create
 */
 function mkDirIfNeeded(dir) {
-    shelljs.mkdir('-p', dir);
+    if (dir != '') {
+        shelljs.mkdir('-p', dir);
+    }
 }
 
 /**
@@ -255,7 +257,7 @@ function replaceInFiles(from, to, files) {
  */
 function moveFile(from, to) {
     logDebug('Moving: ' + from + ' to ' + to);
-    shelljs.mkdir('-p', path.parse(to).dir);
+    mkDirIfNeeded('-p', path.parse(to).dir);
     shelljs.mv(from, to);
 }
 


### PR DESCRIPTION
**The generated application for the new apptype contains a server project that uses Lightning Web Components with Mobile SDK.**

This PR for the new templates is: https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/272

The screenshot below shows:
* the output of running forcehybrid with the new apptype. Note the new "next steps" instructions for the server project,
* what the basic lwc template app looks like.

![Screenshot 2020-06-18 18 00 01](https://user-images.githubusercontent.com/1012459/85085889-0d031680-b18e-11ea-9b0a-e639121ff040.png)
