### PR TITLE
Changing max version for cocoapod

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -49,7 +49,7 @@ module.exports = {
         pod: {
             checkCmd: 'pod --version',
             minVersion: '1.7.2',
-            maxVersion: '1.9.1'
+            maxVersion: '1.9.3'
         },
         cordova: {
             checkCmd: 'cordova -v',


### PR DESCRIPTION
I wonder if we should leave the max version open ended like we do for node and npm.