### PR TITLE
Dropping max version for cocoapod

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -48,8 +48,7 @@ module.exports = {
         },
         pod: {
             checkCmd: 'pod --version',
-            minVersion: '1.7.2',
-            maxVersion: '1.9.3'
+            minVersion: '1.7.2'
         },
         cordova: {
             checkCmd: 'cordova -v',

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -49,7 +49,7 @@ module.exports = {
         pod: {
             checkCmd: 'pod --version',
             minVersion: '1.7.2',
-            maxVersion: '1.9.1'
+            maxVersion: '1.9.3'
         },
         cordova: {
             checkCmd: 'cordova -v',


### PR DESCRIPTION
It's unlikely cocoapod 2 will release any time soon. I don't expect 1.9.x to break anything.
