### PR TITLE
Fixing some of the log lines coming from test_force.js

### DIFF
--- a/test/test_force.js
+++ b/test/test_force.js
@@ -498,6 +498,12 @@ function computeAppName(os, actualAppType, templateRepoUri) {
 // Compute target description
 // 
 function computeTargetDescription(os, actualAppType, templateRepoUri) {
+    if (templateRepoUri.indexOf("https://") == -1) {
+        // we allow template name in place of a uri
+        // in that case, let's build full URI so that generated target description is correct
+        var templateUriParsed = utils.separateRepoUrlPathBranch(SDK.templatesRepoUri);
+        templateRepoUri = templateUriParsed.repo + "/" + templateRepoUri + "#" + templateUriParsed.branch
+    }
     return actualAppType + ' app for ' + os
         + (templateRepoUri
            ? ' based on template ' + getTemplateNameFromUri(templateRepoUri) + ' (' + getTemplateVersionFromUri(templateRepoUri) + ')'


### PR DESCRIPTION
For a while now, we have allowed a template name instead of a full URI.
As a result, some of the generated messages in test_force.js were no longer correct (they were trying to parse out the branch from the name, finding none, and concluding it was coming from master).