### PR TITLE
New apptype for forcereact: react_native_typescript

### DIFF
--- a/sfdx/package.json
+++ b/sfdx/package.json
@@ -35,7 +35,7 @@
         "jsonlint": "^1.6.3"
     },
     "devDependencies": {
-        "@oclif/dev-cli": "^1.22.2"
+        "@oclif/dev-cli": "^1.26.0"
     },
     "repository": {
         "type": "git",

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -52,7 +52,7 @@ module.exports = {
         },
         pod: {
             checkCmd: 'pod --version',
-            minVersion: '1.7.2'
+            minVersion: '1.8.0'
         },
         cordova: {
             checkCmd: 'cordova -v',

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -129,9 +129,10 @@ module.exports = {
             dir: 'react',
             platforms: ['ios', 'android'],
             toolNames: ['git', 'node', 'yarn', 'pod'],
-            appTypes: ['react_native'],
+            appTypes: ['react_native_typescript', 'react_native'],
             appTypesToPath: {
-                'react_native': 'ReactNativeTemplate'
+                'react_native': 'ReactNativeTemplate',
+                'react_native_typescript': 'ReactNativeTypeScriptTemplate'
             },
             commands: ['create', 'createwithtemplate', 'version', 'listtemplates', 'checkconfig']
         }

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -22,8 +22,10 @@ var APP_TYPE = {
     native_swift: 'native_swift',
     native_kotlin: 'native_kotlin',
     react_native: 'react_native',
+    react_native_typescript: 'react_native_typescript',
     hybrid_local: 'hybrid_local',
-    hybrid_remote: 'hybrid_remote'
+    hybrid_remote: 'hybrid_remote',
+    hybrid_lwc: 'hybrid_lwc'
 };
 
 var defaultStartPage = '/apex/testPage';
@@ -181,8 +183,8 @@ function shortUsage(exitCode) {
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);
-    utils.logInfo('  - cliX is : forceios or forcedroid or forcehybrid or forcereact', COLOR.cyan);
-    utils.logInfo('  - appTypeX is: native, native_swift, native_kotlin, react_native, hybrid_local or hybrid_remote', COLOR.cyan);
+    utils.logInfo('  - cliX is : ' + Object.keys(SDK.forceclis).join(' or '), COLOR.cyan);
+    utils.logInfo('  - appTypeX is: ' + Object.values(APP_TYPE).join(' or '), COLOR.cyan);
     utils.logInfo('  - templaterepouri is a template repo uri or a Mobile SDK template name', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
 
@@ -278,8 +280,8 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
 function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested) {
     var execArgs = '';
     var isNative = actualAppType == APP_TYPE.native || actualAppType == APP_TYPE.native_swift || actualAppType == APP_TYPE.native_kotlin; 
-    var isReactNative = actualAppType == APP_TYPE.react_native;
-    var isHybrid = actualAppType.indexOf('hybrid') == 0;
+    var isReactNative = actualAppType == APP_TYPE.react_native || actualAppType == APP_TYPE.react_native_typescript;
+    var isHybrid = actualAppType == APP_TYPE.hybrid_local || actualAppType == APP_TYPE.hybrid_remote || actualAppType == APP_TYPE.hybrid_lwc;
     var isHybridRemote = actualAppType == APP_TYPE.hybrid_remote;
     if (isHybridRemote) {
         // XXX createwithtemplate doesn't work for hybrid remote template


### PR DESCRIPTION
It is also the default when using forcereact.

- Change to usage
```shell
$ forcereact

forcereact: Tool for building a React Native mobile application using Salesforce Mobile SDK

Usage:

# create a React Native mobile application
forcereact create
    --platform=comma-separated list of platforms (ios, android)
    [--apptype=application type (react_native_typescript or react_native, leave empty for react_native_typescript)]
    --appname=application name
    --packagename=app package identifier (e.g. com.mycompany.myapp)
    --organization=organization name (your company's/organization's name)
    [--outputdir=output directory (leave empty for current directory)]
(...)
```

- Change when running forcereact create
```
$ forcereact create
Enter the target platform(s) separated by commas (ios, android): ios
Enter your application type (react_native_typescript or react_native, leave empty for react_native_typescript): 
Enter your application name: TestApp
Enter your package name: com.salesforce
Enter your organization name (Acme, Inc.): Acme
Enter output directory for your app (leave empty for the current directory): 

********************************************************************************
*
*   Creating ios react_native application using Salesforce Mobile SDK
*     with app name:        TestApp
*          package name:    com.salesforce
*          organization:    Acme
*   
*     in:                   TestApp
*   
*     from template repo:   https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev
*          template path:   ReactNativeTypeScriptTemplate
*
********************************************************************************
(...)
```