### PR TITLE
Getting ready for 9.1.1

### DIFF
--- a/release/release.js
+++ b/release/release.js
@@ -46,8 +46,8 @@ const masterBranchDefault = "master2"
 const devBranchDefault = "dev2"
 const docBranchDefault = "gh-pages2"
 const versionReleasedDefault = VERSION
-const versionCodeReleasedDefault = 72
 const nextVersionDefault = "9.2.0"
+const versionCodeReleasedDefault = 73
 
 // Questions
 const QUESTIONS = [

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -28,7 +28,7 @@
 var path = require('path'),
     shelljs = require('shelljs');
 
-var VERSION= '9.2.0';
+var VERSION= '9.1.1';
 
 module.exports = {
     version: VERSION,


### PR DESCRIPTION
NB: no need to run setversions.sh on the various repos to set them to 9.1.1 (they currently are set to 9.2.0), the release script takes care of it.

I ran a full "dry" run of the release, including running test_force.js and found not issues. 
See branches dev2 and master2 on the various repos in my forks.