### PR TITLE
Good news hybrid apps compile with Xcode 13 GA (did not compile with …

### DIFF
--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -143,7 +143,9 @@ function useLegacyBuild(config, iosSubDir) {
         '<plist version="1.0">\n' + 
         '<dict>\n'  +
         '<key>BuildSystemType</key>\n' + 
-        '<string>Original</string>\n' + 
+        '<string>Original</string>\n' +
+        '<key>DisableBuildSystemDeprecationDiagnostic</key>\n' + 
+	    '<true/>\n' +
         '</dict>\n' + 
         '</plist>\n';
     utils.logInfo('Creating WorkspaceSettings.xcsettings for project. Setting the BuildSystemType to original in ' + xcSettingsFile);


### PR DESCRIPTION
…Xcode 13 beta)

But we still need to use the legacy build system.
This change is to avoid getting a build issue because we are using the old build system