### PR TITLE
Release.js (and setup_test_branches.js) can now be used for patch releases

### DIFF
--- a/release/common.js
+++ b/release/common.js
@@ -84,7 +84,7 @@ async function runCmds(dir, cmds, depth) {
                   : (cmd.reldir
                      ? path.join(dir, cmd.reldir)
                      : dir)
-            await runCmd(cmdDir, cmd.cmd, i+1, count, depth, cmd.ignoreError)
+            await runCmd(cmdDir, cmd.cmd, i+1, count, depth, cmd.ignoreError, cmd.cmdIfError)
         } else if (cmd.cmds) {
             print(cmd.msg, i+1, count, depth)
             await runCmds(dir, cmd, depth + 1)
@@ -107,12 +107,14 @@ async function proceedPrompt(msg) {
 }
 
 
-async function runCmd(dir, cmd, index, count, depth, ignoreError) {
+async function runCmd(dir, cmd, index, count, depth, ignoreError, cmdIfError) {
     print(`${dir} > ${cmd}`, index, count, depth)
     try {
         utils.runProcessThrowError(cmd, dir)
     } catch (e) {
-        if (!ignoreError && !await proceedPrompt('An error occurred. Continue?')) {
+        if (cmdIfError) {
+            await runCmds(dir, cmdIfError, depth+1)
+        } else if (!ignoreError && !await proceedPrompt('An error occurred. Continue?')) {
             process.exit(1);
         }
     }

--- a/release/package.json
+++ b/release/package.json
@@ -4,8 +4,17 @@
         "node": ">=8.10.0"
     },
     "dependencies": {
-        "prompts": "^2.1.0",
-        "shelljs": "0.8.4"
+        "@oclif/command": "^1.8.0",
+        "@oclif/config": "^1.17.0",
+        "@oclif/dev-cli": "^1.26.0",
+        "@oclif/errors": "^1.3.5",
+        "@oclif/plugin-help": "^2.2.3",
+        "@salesforce/core": "^1.3.3",
+        "ajv": "^6.12.6",
+        "globby": "^9.2.0",
+        "jsonlint": "^1.6.3",
+        "prompts": "^2.4.1",
+        "shelljs": "^0.8.4"
     },
     "author": {
         "name": "Wolfgang Mathurin",

--- a/release/release.js
+++ b/release/release.js
@@ -394,7 +394,7 @@ function mergeBranch(branchToMergeFrom, branchToMergeInto, submodulePaths) {
     const msg = `Merging ${branchToMergeFrom} into ${branchToMergeInto}`
     return {
         msg: msg,
-        cmd: `git merge -Xours --no-ff -m "${msg}" ${branchToMergeFrom}`,
+        cmd: `git merge -Xours --no-ff -m "${msg}" origin/${branchToMergeFrom}`,
         cmdIfError: !submodulePaths
             ? null
             : {

--- a/release/release.js
+++ b/release/release.js
@@ -397,7 +397,7 @@ function checkoutDevAndMergeMaster() {
             `git clean -fdxf`, // NB: need double -f to remove deleted submodule directory - see https://stackoverflow.com/a/10761699
             `git submodule sync`,
             `git submodule update`,
-            `git merge -Xours --no-ff -m "Merging ${config.masterBranch} into ${config.devBranch}" ${config.masterBranch}`,
+            `git merge -Xours --no-ff -m "Merging ${config.masterBranch} into ${config.devBranch}" ${config.masterBranch}`
         ]
     }
 }

--- a/release/setup_test_branches.js
+++ b/release/setup_test_branches.js
@@ -187,7 +187,9 @@ async function prepareRepo(repo, params) {
                     {
                         msg: `Setting up ${config.testMasterBranch}`,
                         cmds: [
-                            createBranch(config.testMasterBranch, 'master'), 
+                            createBranch(config.testMasterBranch, 'master'),
+                            // leaving submodule alone during regular release
+                            // otherwise merge from dev to master will confict (git does not do any merge operations on submodule versions)
                             (params.noDev || config.isPatch) && params.filesWithOrg ? pointToFork(config.testMasterBranch, params) : null,
                             config.isPatch && params.submodulePaths ? updateSubmodules(config.testMasterBranch, params) : null  
                         ]
@@ -198,8 +200,10 @@ async function prepareRepo(repo, params) {
                         cmds: [
                             createBranch(config.testDevBranch, 'dev'),
                             mergeMasterToDev(),
-                            params.filesWithOrg ? pointToFork(config.testDevBranch, params) : null,
-                            params.submodulePaths ? updateSubmodules(config.testDevBranch, params) : null
+                            // leaving submodule alone for patch release
+                            // otherwise merge from master to dev will confict (git does not do any merge operations on submodule versions)
+                            !config.isPatch && params.filesWithOrg ? pointToFork(config.testDevBranch, params) : null,
+                            !config.isPatch && params.submodulePaths ? updateSubmodules(config.testDevBranch, params) : null
                         ]
                     }
                 ]

--- a/release/setup_test_branches.js
+++ b/release/setup_test_branches.js
@@ -332,8 +332,6 @@ function validateConfig() {
         utils.logError(`You can't use ${config.testDocBranch} for testing`)
         process.exit(1)
     }
-
-    console.log(`${config.testVersion} < ${VERSION}`)
     
     if (config.testVersion < VERSION) {
         utils.logError(`You can't use ${config.testVersion} for testing`)

--- a/release/setup_test_branches.js
+++ b/release/setup_test_branches.js
@@ -79,12 +79,6 @@ const QUESTIONS = [
         initial: testOrgDefault
     },
     {
-        type:'confirm',
-        name: 'isPatch',
-        message: `Is for patch release? (no merge from dev, changes already in master)`,
-        initial: false
-    },    
-    {
         type: 'text',
         name: 'testMasterBranch',
         message: 'Name of test master branch ?',
@@ -188,10 +182,8 @@ async function prepareRepo(repo, params) {
                         msg: `Setting up ${config.testMasterBranch}`,
                         cmds: [
                             createBranch(config.testMasterBranch, 'master'),
-                            // leaving submodule alone during regular release
-                            // otherwise merge from dev to master will confict (git does not do any merge operations on submodule versions)
-                            (params.noDev || config.isPatch) && params.filesWithOrg ? pointToFork(config.testMasterBranch, params) : null,
-                            config.isPatch && params.submodulePaths ? updateSubmodules(config.testMasterBranch, params) : null  
+                            params.filesWithOrg ? pointToFork(config.testMasterBranch, params) : null,
+                            params.submodulePaths ? updateSubmodules(config.testMasterBranch, params) : null  
                         ]
                     },
                     params.hasDoc ? createBranch(config.testDocBranch, 'gh-pages') : null,
@@ -200,10 +192,8 @@ async function prepareRepo(repo, params) {
                         cmds: [
                             createBranch(config.testDevBranch, 'dev'),
                             mergeMasterToDev(),
-                            // leaving submodule alone for patch release
-                            // otherwise merge from master to dev will confict (git does not do any merge operations on submodule versions)
-                            !config.isPatch && params.filesWithOrg ? pointToFork(config.testDevBranch, params) : null,
-                            !config.isPatch && params.submodulePaths ? updateSubmodules(config.testDevBranch, params) : null
+                            params.filesWithOrg ? pointToFork(config.testDevBranch, params) : null,
+                            params.submodulePaths ? updateSubmodules(config.testDevBranch, params) : null
                         ]
                     }
                 ]


### PR DESCRIPTION
A patch release is one where the changes are already in master and for which no dev to master merge should take place.

I'm currently testing by make "dry runs" of:
* a 9.2.1 patch release
* a 10.0.0 regular release

Issues I was running into had to do with the "dry run" setup which consists in having master2 dev2 branches setup everywhere and correctly referenced in submodules etc. When done improperly, it can lead to conflicts during merges (especially when submodules are involved).