### PR TITLE
Modernize CircleCI config and add iOS beta runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,10 @@
 aliases:
+#  Xcode version announcments can be found here: https://discuss.circleci.com/c/announcements/
+#  Each post contains a full image manifest, including iOS runtimes, devices, CocoaPods version, etc.
+#  NOTE: When updaing Xcode check the manifest for compatible chruby versions.
+  - &latest-xcode "13.4.1"
+  - &beta-xcode "14.0.0"
+
   - &upgrade-cocoapods
     name: Upgrade Cocoapods
     command:  |
@@ -41,24 +47,34 @@ aliases:
       fi
     when: always
 
-linux: &linux
-  working_directory: ~/SalesforceMobileSDK-Package
-  docker:
-    - image: cimg/android:2022.03.1-node
-  environment:
-    - TERM: "dumb"
-    - GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+version: 2.1
+executors:
+  linux:
+    working_directory: ~/SalesforceMobileSDK-Package
+    docker:
+      - image: cimg/android:2022.08.1-node
+    environment:
+      - GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+  mac:
+    working_directory: ~/SalesforceMobileSDK-Package
+    macos:
+      xcode: *latest-xcode
+    shell: /bin/bash --login -eo pipefail
+    environment:
+      BASH_ENV: ~/.bashrc
+      FASTLANE_SKIP_UPDATE_CHECK: "true"
+  mac-beta:
+    working_directory: ~/SalesforceMobileSDK-Package
+    macos:
+      xcode: *beta-xcode
+    shell: /bin/bash --login -eo pipefail
+    environment:
+      BASH_ENV: ~/.bashrc
+      FASTLANE_SKIP_UPDATE_CHECK: "true"
 
-mac: &mac
-  working_directory: ~/SalesforceMobileSDK-Package
-  macos:
-    xcode: "13.2.1"
-  shell: /bin/bash --login -eo pipefail
-
-version: 2
 jobs:
   forcedroid:
-    <<: *linux
+    executor: linux
     steps:
       - checkout
       - run: *setup
@@ -68,7 +84,7 @@ jobs:
           when: always
 
   forcedroid-sfdx:
-    <<: *linux
+    executor: linux
     steps:
       - checkout
       - run: *setup
@@ -79,7 +95,7 @@ jobs:
           when: always
 
   forcehybrid-android:
-    <<: *linux
+    executor: linux
     steps:
       - checkout
       - run: *setup
@@ -91,7 +107,7 @@ jobs:
           when: always
 
   forcehybrid-android-sfdx:
-    <<: *linux
+    executor: linux
     steps:
       - checkout
       - run: *setup
@@ -103,7 +119,7 @@ jobs:
           when: always
 
   forcereact-android:
-    <<: *linux
+    executor: linux
     steps:
       - checkout
       - run: *setup
@@ -114,7 +130,7 @@ jobs:
           when: always
 
   forcereact-android-sfdx:
-    <<: *linux
+    executor: linux
     steps:
       - checkout
       - run: *setup
@@ -126,7 +142,11 @@ jobs:
           when: always
 
   forceios:
-    <<: *mac
+    parameters:
+      env:
+        type: string
+        default: "mac"
+    executor: << parameters.env >>
     steps:
       - checkout
       - run: *setup
@@ -137,7 +157,11 @@ jobs:
           when: always
 
   forceios-sfdx:
-    <<: *mac
+    parameters:
+      env:
+        type: string
+        default: "mac"
+    executor: << parameters.env >>
     steps:
       - checkout
       - run: *setup
@@ -149,7 +173,11 @@ jobs:
           when: always
 
   forcehybrid-ios:
-    <<: *mac
+    parameters:
+      env:
+        type: string
+        default: "mac"
+    executor: << parameters.env >>
     steps:
       - checkout
       - run: *setup
@@ -164,7 +192,11 @@ jobs:
           when: always
 
   forcehybrid-ios-sfdx:
-    <<: *mac
+    parameters:
+      env:
+        type: string
+        default: "mac"
+    executor: << parameters.env >>
     steps:
       - checkout
       - run: *setup
@@ -179,7 +211,11 @@ jobs:
           when: always
 
   forcereact-ios:
-    <<: *mac
+    parameters:
+      env:
+        type: string
+        default: "mac"
+    executor: << parameters.env >>
     steps:
       - checkout
       - run: *setup
@@ -191,7 +227,11 @@ jobs:
           when: always
 
   forcereact-ios-sfdx:
-    <<: *mac
+    parameters:
+      env:
+        type: string
+        default: "mac"
+    executor: << parameters.env >>
     steps:
       - checkout
       - run: *setup
@@ -203,10 +243,18 @@ jobs:
           command: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios --use-sfdx
           when: always
 
+#  Potential parameters that can come from the project GUI Triggers
+parameters:
+  beta:
+    type: boolean
+    default: false
+
 workflows:
   version: 2
 
   pr-build-all-apps:
+    when: 
+      equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - forceios
       - forcehybrid-ios
@@ -221,16 +269,11 @@ workflows:
       - forcehybrid-android-sfdx
       - forcereact-android-sfdx
 
-  # Cron are on a timezone 8 hours ahead of PST
-  # Build everything at ~8:30pm Sunday/Wednesday Nights
+  # Build everything at 8:00 PM PST Wednesday and Sunday
   weekly-build-all-apps:
-    triggers:
-      - schedule:
-          cron: "30 4 * * 2,4,6"
-          filters:
-            branches:
-              only:
-                - dev
+    when: 
+      not:
+        equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - forceios
       - forcehybrid-ios
@@ -244,3 +287,24 @@ workflows:
       - forcedroid-sfdx
       - forcehybrid-android-sfdx
       - forcereact-android-sfdx
+
+  # Build everything iOS wtih Beta Xcode at 9:00 PM PST Wednesday and Sunday
+  weekly-build-all-apps-ios-beta:
+    when: 
+      and:
+        - << pipeline.parameters.beta >>
+        - not:
+            equal: [ "webhook", << pipeline.trigger_source >> ]
+    jobs:
+      - forceios:
+          env: "mac-beta"
+      - forcehybrid-ios:
+          env: "mac-beta"
+      - forcereact-ios:
+          env: "mac-beta"
+      - forceios-sfdx:
+          env: "mac-beta"
+      - forcehybrid-ios-sfdx:
+          env: "mac-beta"
+      - forcereact-ios-sfdx:
+          env: "mac-beta"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,10 @@ aliases:
       fi
     when: always
 
+  - &install-android-build-tools-32
+    name: Install Android Build Tools 32.0.0
+    command: sdkmanager --install "build-tools;32.0.0"
+
 version: 2.1
 executors:
   linux:
@@ -95,6 +99,7 @@ jobs:
       - run: *setup
       - run: *install-cordova
       - run: *install-sfdx
+      - run: *install-android-build-tools-32
       - run:
           name: Building all android hybrid templates
           command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --no-plugin-update
@@ -107,6 +112,7 @@ jobs:
       - run: *setup
       - run: *install-cordova
       - run: *install-sfdx
+      - run: *install-android-build-tools-32
       - run:
           name: Building all android hybrid templates with SFDX
           command: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --use-sfdx --no-plugin-update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,8 @@ aliases:
 #  Xcode version announcments can be found here: https://discuss.circleci.com/c/announcements/
 #  Each post contains a full image manifest, including iOS runtimes, devices, CocoaPods version, etc.
   - &latest-xcode "13.4.1"
-  - &beta-xcode "14.0.0"
+  - &latest-android  "cimg/android:2022.09.2-node"
+  - &invalid      ""
 
   - &setup
     name: Setup
@@ -45,30 +46,25 @@ aliases:
     name: Install Android Build Tools 32.0.0
     command: sdkmanager --install "build-tools;32.0.0"
 
+  - &mac-env
+    parameters:
+      xcode: 
+        type: string
+        default: *latest-xcode
+    macos: 
+      xcode: << parameters.xcode >>
+    working_directory: ~/SalesforceMobileSDK-Package
+    environment:
+      FASTLANE_SKIP_UPDATE_CHECK: "true"
+
 version: 2.1
 executors:
   linux:
     working_directory: ~/SalesforceMobileSDK-Package
     docker:
-      - image: cimg/android:2022.08.1-node
+      - image: *latest-android
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-  mac:
-    working_directory: ~/SalesforceMobileSDK-Package
-    macos:
-      xcode: *latest-xcode
-    shell: /bin/bash --login -eo pipefail
-    environment:
-      BASH_ENV: ~/.bashrc
-      FASTLANE_SKIP_UPDATE_CHECK: "true"
-  mac-beta:
-    working_directory: ~/SalesforceMobileSDK-Package
-    macos:
-      xcode: *beta-xcode
-    shell: /bin/bash --login -eo pipefail
-    environment:
-      BASH_ENV: ~/.bashrc
-      FASTLANE_SKIP_UPDATE_CHECK: "true"
 
 jobs:
   forcedroid:
@@ -142,11 +138,7 @@ jobs:
           when: always
 
   forceios:
-    parameters:
-      env:
-        type: string
-        default: "mac"
-    executor: << parameters.env >>
+    <<: *mac-env
     steps:
       - checkout
       - run: *setup
@@ -156,11 +148,7 @@ jobs:
           when: always
 
   forceios-sfdx:
-    parameters:
-      env:
-        type: string
-        default: "mac"
-    executor: << parameters.env >>
+    <<: *mac-env
     steps:
       - checkout
       - run: *setup
@@ -171,11 +159,7 @@ jobs:
           when: always
 
   forcehybrid-ios:
-    parameters:
-      env:
-        type: string
-        default: "mac"
-    executor: << parameters.env >>
+    <<: *mac-env
     steps:
       - checkout
       - run: *setup
@@ -189,11 +173,7 @@ jobs:
           when: always
 
   forcehybrid-ios-sfdx:
-    parameters:
-      env:
-        type: string
-        default: "mac"
-    executor: << parameters.env >>
+    <<: *mac-env
     steps:
       - checkout
       - run: *setup
@@ -207,11 +187,7 @@ jobs:
           when: always
 
   forcereact-ios:
-    parameters:
-      env:
-        type: string
-        default: "mac"
-    executor: << parameters.env >>
+    <<: *mac-env
     steps:
       - checkout
       - run: *setup
@@ -222,11 +198,7 @@ jobs:
           when: always
 
   forcereact-ios-sfdx:
-    parameters:
-      env:
-        type: string
-        default: "mac"
-    executor: << parameters.env >>
+    <<: *mac-env
     steps:
       - checkout
       - run: *setup
@@ -239,9 +211,9 @@ jobs:
 
 #  Potential parameters that can come from the project GUI Triggers
 parameters:
-  beta:
-    type: boolean
-    default: false
+  xcode:
+    type: string
+    default: *invalid
 
 workflows:
   version: 2
@@ -267,7 +239,9 @@ workflows:
   weekly-build-all-apps:
     when: 
       not:
-        equal: [ "webhook", << pipeline.trigger_source >> ]
+        and:
+          - << pipeline.parameters.xcode >>
+          - equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - forceios
       - forcehybrid-ios
@@ -286,19 +260,19 @@ workflows:
   weekly-build-all-apps-ios-beta:
     when: 
       and:
-        - << pipeline.parameters.beta >>
+        - << pipeline.parameters.xcode >>
         - not:
             equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - forceios:
-          env: "mac-beta"
+          xcode: << pipeline.parameters.xcode >>
       - forcehybrid-ios:
-          env: "mac-beta"
+          xcode: << pipeline.parameters.xcode >>
       - forcereact-ios:
-          env: "mac-beta"
+          xcode: << pipeline.parameters.xcode >>
       - forceios-sfdx:
-          env: "mac-beta"
+          xcode: << pipeline.parameters.xcode >>
       - forcehybrid-ios-sfdx:
-          env: "mac-beta"
+          xcode: << pipeline.parameters.xcode >>
       - forcereact-ios-sfdx:
-          env: "mac-beta"
+          xcode: << pipeline.parameters.xcode >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,11 +237,11 @@ workflows:
 
   # Build everything at 8:00 PM PST Wednesday and Sunday
   weekly-build-all-apps:
-    when: 
-      not:
-        and:
-          - << pipeline.parameters.xcode >>
-          - equal: [ "webhook", << pipeline.trigger_source >> ]
+    when:
+      and:
+        - not: << pipeline.parameters.xcode >>
+        - not: 
+            equal: [ "webhook", << pipeline.trigger_source >> ]
     jobs:
       - forceios
       - forcehybrid-ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,8 @@
 aliases:
 #  Xcode version announcments can be found here: https://discuss.circleci.com/c/announcements/
 #  Each post contains a full image manifest, including iOS runtimes, devices, CocoaPods version, etc.
-#  NOTE: When updaing Xcode check the manifest for compatible chruby versions.
   - &latest-xcode "13.4.1"
   - &beta-xcode "14.0.0"
-
-  - &upgrade-cocoapods
-    name: Upgrade Cocoapods
-    command:  |
-      sudo gem install cocoapods -v 1.10.1
 
   - &setup
     name: Setup
@@ -54,7 +48,7 @@ executors:
     docker:
       - image: cimg/android:2022.08.1-node
     environment:
-      - GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
   mac:
     working_directory: ~/SalesforceMobileSDK-Package
     macos:
@@ -150,7 +144,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *upgrade-cocoapods
       - run:
           name: Building all ios native templates
           command:  ./test/test_force.js --exit-on-failure --cli=forceios
@@ -165,7 +158,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *upgrade-cocoapods
       - run: *install-sfdx
       - run:
           name: Building all ios native templates with SFDX
@@ -181,7 +173,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *upgrade-cocoapods
       - run: *install-cordova
       - run: *install-sfdx
       - run:
@@ -200,7 +191,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *upgrade-cocoapods
       - run: *install-cordova
       - run: *install-sfdx
       - run:
@@ -219,7 +209,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *upgrade-cocoapods
       - run: *install-typescript
       - run:
           name: Building all ios react native templates
@@ -235,7 +224,6 @@ jobs:
     steps:
       - checkout
       - run: *setup
-      - run: *upgrade-cocoapods
       - run: *install-sfdx
       - run: *install-typescript
       - run:

--- a/android/package.json
+++ b/android/package.json
@@ -13,7 +13,7 @@
         "node": ">=7.0.0"
     },
     "dependencies": {
-        "shelljs": "0.8.4",
+        "shelljs": "0.8.5",
         "ajv": "^6.10.2",
 		"jsonlint": "^1.6.3"
     },

--- a/hybrid/package.json
+++ b/hybrid/package.json
@@ -10,7 +10,7 @@
 	],
 	"bin" : { "forcehybrid" : "forcehybrid.js" },
     "dependencies": {
-        "shelljs": "0.8.4",
+        "shelljs": "0.8.5",
         "ajv": "^6.10.2",
 		"jsonlint": "^1.6.3"
     },

--- a/ios/package.json
+++ b/ios/package.json
@@ -14,7 +14,7 @@
     },
 	"bin" : { "forceios" : "forceios.js" },
     "dependencies": {
-        "shelljs": "0.8.4",
+        "shelljs": "0.8.5",
         "ajv": "^6.10.2",
 		"jsonlint": "^1.6.3"
     },

--- a/react/package.json
+++ b/react/package.json
@@ -10,7 +10,7 @@
 	],
 	"bin" : { "forcereact" : "forcereact.js" },
     "dependencies": {
-        "shelljs": "0.8.4",
+        "shelljs": "0.8.5",
         "ajv": "^6.10.2",
 		"jsonlint": "^1.6.3"
     },

--- a/release/package.json
+++ b/release/package.json
@@ -14,7 +14,7 @@
         "globby": "^9.2.0",
         "jsonlint": "^1.6.3",
         "prompts": "^2.4.1",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.5"
     },
     "author": {
         "name": "Wolfgang Mathurin",

--- a/sfdx/package.json
+++ b/sfdx/package.json
@@ -32,7 +32,7 @@
         "ajv": "^6.10.2",
         "globby": "^9.0.0",
         "jsonlint": "^1.6.3",
-        "shelljs": "0.8.4"
+        "shelljs": "0.8.5"
     },
     "devDependencies": {
         "@oclif/dev-cli": "^1.26.0"

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -67,7 +67,7 @@ function createHybridApp(config) {
 
     // Create app with cordova
     utils.runProcessThrowError('cordova create "' + config.projectDir + '" ' + config.packagename + ' ' + config.appname);
-    utils.runProcessThrowError('npm install shelljs@0.8.4', config.projectDir);
+    utils.runProcessThrowError('npm install shelljs@0.8.5', config.projectDir);
 
     for (var platform of config.platform.split(',')) {
         utils.runProcessThrowError('cordova platform add ' + platform + '@' + SDK.tools.cordova.platformVersion[platform], config.projectDir);


### PR DESCRIPTION
- Add Xcode 14/iOS 16 beta runs.
- Convert triggers from deprecated Scheduled Workflows to Scheduled Pipelines, specified in "Triggers" tab of project settings on CircleCi website. This change makes triggering tests manually though the GUI possible (and easy) against any branch.