### PR TITLE
Project generated when targeting ios and android was not building in …

### DIFF
--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -109,7 +109,7 @@ function createHybridApp(config) {
     // Run cordova prepare
     utils.runProcessThrowError('cordova prepare', config.projectDir);
 
-    if (config.platform === 'ios') {
+    if (config.platform.split(',').indexOf('ios') != -1) {
 	if (utils.getToolVersion('xcodebuild -version') < 14000000) {
             // Use legacy build for xcode 13 and older
 	    useLegacyBuild(config, path.join('platforms', 'ios'));


### PR DESCRIPTION
…Xcode 14

The post-install patching was not happening because the if was for config.platform being exactly ios (when it can be multiple comma separated platforms).