### PR TITLE
Sf cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ aliases:
     name: Install SFDX
     command: |
       if [[ "$OSTYPE" == "linux-gnu" ]]; then
-        sudo npm install -g sfdx-cli
+        sudo npm install -g @salesforce/cli
       else 
-        npm install -g sfdx-cli
+        npm install -g @salesforce/cli
       fi
     when: always
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CircleCI](https://circleci.com/gh/forcedotcom/SalesforceMobileSDK-Package/tree/dev.svg?style=svg)](https://circleci.com/gh/forcedotcom/SalesforceMobileSDK-Package/tree/dev)
 
 # SalesforceMobileSDK-Package
-Repo for forceios/forcedroid/forcehybrid/forcereact and the sfdx plugin.
+Repo for forceios/forcedroid/forcehybrid/forcereact and the Salesforce CLI plugin.
 
 ## To get started do the following from the root directory
 ``` shell
@@ -28,25 +28,25 @@ node ./install.js
 ./react/forcereact.js
 ```
 
-## To load the sfdx plugin from source do
+## To load the sf plugin from source do
 ```shell
-sfdx plugins:link sfdx
+sf plugins link sfdx
 ```
 
-## To run the sfdx plugin do
+## To run the Salesforce CLI plugin do
 ```shell
-sfdx mobilesdk:ios --help 
-sfdx mobilesdk:android --help 
-sfdx mobilesdk:hybrid --help 
-sfdx mobilesdk:reactnative --help
+sf mobilesdk ios --help 
+sf mobilesdk android --help 
+sf mobilesdk hybrid --help 
+sf mobilesdk reactnative --help
 ```
 
-## To test forceios, forcedroid, forcehybrid, forcereact or the sfdx plugin do
+## To test forceios, forcedroid, forcehybrid, forcereact or the Salesforce CLI plugin do
 ```shell
 ./test/test_force.js
 ```
 
-## To npm pack forceios, forcedroid, forcehybrid, forcereact or the sfx plugin do
+## To npm pack forceios, forcedroid, forcehybrid, forcereact or the Salesforce CLI plugin do
 ```shell
 ./pack/pack.js
 ```

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -14,11 +14,11 @@ A plugin for the Salesforce CLI to create mobile applications to interface with 
 
 4. Generate oclif command classes `./sfdx/generate_oclif.js`
 
-5. Link the plugin: `sf plugins:link sfdx`
+5. Link the plugin: `sf plugins link sfdx`
 
 ### Install as plugin
 
-1. Install plugin: `sf plugins:install sfdx-mobilesdk-plugin`
+1. Install plugin: `sf plugins install sfdx-mobilesdk-plugin`
 
 ## Help
 ```
@@ -39,7 +39,7 @@ TOPICS
 ## Create a native iOS application 
 ### Help for iOS
 ```
--> sf mobilesdk:ios --help
+-> sf mobilesdk ios --help
 create an iOS native mobile application
 
 USAGE
@@ -58,7 +58,7 @@ COMMANDS
 
 ### Create Objective-C (native) or Swift (native_swift) application
 ```
--> sf mobilesdk:ios:create --help
+-> sf mobilesdk ios create --help
 create an iOS native mobile application
 
 USAGE
@@ -86,7 +86,7 @@ DESCRIPTION
 
 ### List available native iOS templates
 ```
--> sf mobilesdk:ios:listtemplates --help
+-> sf mobilesdk ios listtemplates --help
 list available Mobile SDK templates to create an iOS native mobile application
 
 USAGE
@@ -102,7 +102,7 @@ DESCRIPTION
 
 ### Create iOS application from template
 ```
--> sf mobilesdk:ios:createwithtemplate --help
+-> sf mobilesdk ios createwithtemplate --help
 create an iOS native mobile application from a template
 
 USAGE
@@ -133,7 +133,7 @@ DESCRIPTION
 
 ### Check store or syncs config
 ```
--> sf mobilesdk:ios:checkconfig --help
+-> sf mobilesdk ios checkconfig --help
 validate store or syncs configuration
 
 USAGE
@@ -155,7 +155,7 @@ DESCRIPTION
 ## Create a native Android application 
 ### Help for Android
 ```
--> sf mobilesdk:android --help
+-> sf mobilesdk android --help
 create an Android native mobile application
 
 USAGE
@@ -176,7 +176,7 @@ COMMANDS
 
 ### Create Java (native) or Kotlin (native_kotlin) application
 ```
--> sf mobilesdk:android:create --help
+-> sf mobilesdk android create --help
 create an Android native mobile application
 
 USAGE
@@ -204,7 +204,7 @@ DESCRIPTION
 
 ### List available native Android templates
 ```
--> sf mobilesdk:android:listtemplates --help
+-> sf mobilesdk android listtemplates --help
 list available Mobile SDK templates to create an Android native mobile application
 
 USAGE
@@ -221,7 +221,7 @@ DESCRIPTION
 
 ### Create Android application from template
 ```
--> sf mobilesdk:android:createwithtemplate --help
+-> sf mobilesdk android createwithtemplate --help
 create an Android native mobile application from a template
 
 USAGE
@@ -252,7 +252,7 @@ DESCRIPTION
 
 ### Check store or syncs config
 ```
--> sf mobilesdk:android:checkconfig --help
+-> sf mobilesdk android checkconfig --help
 validate store or syncs configuration
 
 USAGE
@@ -274,7 +274,7 @@ DESCRIPTION
 ## Create an hybrid application 
 ### Help for hybrid
 ```
--> sf mobilesdk:hybrid --help
+-> sf mobilesdk hybrid --help
 create a hybrid mobile application
 
 USAGE
@@ -293,7 +293,7 @@ COMMANDS
 
 ### Create hybrid application
 ```
--> sf mobilesdk:hybrid:create --help
+-> sf mobilesdk hybrid create --help
 create a hybrid mobile application
 
 USAGE
@@ -325,7 +325,7 @@ DESCRIPTION
 
 ### List available hybrid templates
 ```
--> sf mobilesdk:hybrid:listtemplates --help
+-> sf mobilesdk hybrid listtemplates --help
 list available Mobile SDK templates to create a hybrid mobile application
 
 USAGE
@@ -341,7 +341,7 @@ DESCRIPTION
 
 ### Create hybrid application from template
 ```
--> sf mobilesdk:hybrid:createwithtemplate --help
+-> sf mobilesdk hybrid createwithtemplate --help
 create a hybrid mobile application from a template
 
 USAGE
@@ -376,7 +376,7 @@ DESCRIPTION
 
 ### Check store or syncs config
 ```
--> sf mobilesdk:hybrid:checkconfig --help
+-> sf mobilesdk hybrid checkconfig --help
 validate store or syncs configuration
 
 USAGE
@@ -398,7 +398,7 @@ DESCRIPTION
 ## Create a React Native application
 ### Help for React Native
 ```
--> sf mobilesdk:reactnative --help
+-> sf mobilesdk reactnative --help
 create a React Native mobile application
 
 USAGE
@@ -420,7 +420,7 @@ COMMANDS
 
 ### Create React Native application
 ```
--> sf mobilesdk:reactnative:create --help
+-> sf mobilesdk reactnative create --help
 create a React Native mobile application
 
 USAGE
@@ -451,7 +451,7 @@ DESCRIPTION
 
 ### List available React Native templates
 ```
--> sf mobilesdk:reactnative:listtemplates --help
+-> sf mobilesdk reactnative listtemplates --help
 list available Mobile SDK templates to create a React Native mobile application
 
 USAGE
@@ -468,7 +468,7 @@ DESCRIPTION
 
 ### Create React Native application from template
 ```
--> sf mobilesdk:reactnative:createwithtemplate --help
+-> sf mobilesdk reactnative createwithtemplate --help
 create a React Native mobile application from a template
 
 USAGE
@@ -501,7 +501,7 @@ DESCRIPTION
 
 ### Check store or syncs config
 ```
--> sf mobilesdk:reactnative:checkconfig --help
+-> sf mobilesdk reactnative checkconfig --help
 validate store or syncs configuration
 
 USAGE

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -2,25 +2,11 @@
 
 A plugin for the Salesforce CLI to create mobile applications to interface with the [Salesforce Platform](http://www.salesforce.com/platform/overview/), leveraging the [Salesforce Mobile SDK for iOS](https://github.com/forcedotcom/SalesforceMobileSDK-iOS) and the [Salesforce Mobile SDK for Android](https://github.com/forcedotcom/SalesforceMobileSDK-Android) repos.
 
-## Special Note Regarding SFDX and Oclif
-
-SFDX now supports the Heroku "O"pen "CLI" "F"ramework and sfdx-mobilesdk-plugin v7.1.0 has been updated to be compatible. The new plugin will run in both version 6 and version 7 instances of the SFDX cli. However, older versions of the mobilesdk plugin will not work in the Oclif version of the CLI. 
-
-If there is a need to use an older plugin one must first uninstall V7 of the CLI and install a V6 instance.
-
-To determine the latest version of v6 go here:
-
-https://www.npmjs.com/package/sfdx-cli?activeTab=versions
-
-The most reliable way to install a previous version of the CLI is via npm.
-
-`npm install sfdx-cli@<V6 version from npmjs> -g`
-
 ## Setup
 
 ### Install from source
 
-1. Install the SDFX CLI (https://developer.salesforce.com/tools/sfdxcli).
+1. Install the Salesforce CLI (https://developer.salesforce.com/tools/salesforcecli).
 
 2. Clone the repository: `git clone git@github.com:forcedotcom/SalesforceMobileSDK-Package`
 
@@ -28,141 +14,140 @@ The most reliable way to install a previous version of the CLI is via npm.
 
 4. Generate oclif command classes `./sfdx/generate_oclif.js`
 
-5. Link the plugin: `sfdx plugins:link sfdx`
+5. Link the plugin: `sf plugins:link sfdx`
 
 ### Install as plugin
 
-1. Install plugin: `sfdx plugins:install sfdx-mobilesdk-plugin`
+1. Install plugin: `sf plugins:install sfdx-mobilesdk-plugin`
 
 ## Help
 ```
--> sfdx mobilesdk --help
+-> sf mobilesdk --help
 create mobile apps based on the Salesforce Mobile SDK
 
 USAGE
-  $ sfdx mobilesdk:COMMAND
+  $ sf mobilesdk COMMAND
 
 TOPICS
-  mobilesdk:android      create an Android native mobile application
-  mobilesdk:hybrid       create a hybrid mobile application
-  mobilesdk:ios          create an iOS native mobile application
-  mobilesdk:reactnative  create a React Native mobile application
+  mobilesdk android      create an Android native mobile application
+  mobilesdk hybrid       create a hybrid mobile application
+  mobilesdk ios          create an iOS native mobile application
+  mobilesdk reactnative  create a React Native mobile application
 
 ```
 
 ## Create a native iOS application 
 ### Help for iOS
 ```
--> sfdx mobilesdk:ios --help
+-> sf mobilesdk:ios --help
 create an iOS native mobile application
 
 USAGE
-  $ sfdx mobilesdk:ios:COMMAND
+  $ sf mobilesdk ios COMMAND
 
 COMMANDS
-  mobilesdk:ios:checkconfig         validate store or syncs configuration
-  mobilesdk:ios:create              create an iOS native mobile application
-  mobilesdk:ios:createwithtemplate  create an iOS native mobile application from
+  mobilesdk ios checkconfig         validate store or syncs configuration
+  mobilesdk ios create              create an iOS native mobile application
+  mobilesdk ios createwithtemplate  create an iOS native mobile application from
                                     a template
-  mobilesdk:ios:listtemplates       list available Mobile SDK templates to
+  mobilesdk ios listtemplates       list available Mobile SDK templates to
                                     create an iOS native mobile application
-  mobilesdk:ios:version             show version of Mobile SDK
+  mobilesdk ios version             show version of Mobile SDK
 
 ```
 
 ### Create Objective-C (native) or Swift (native_swift) application
 ```
--> sfdx mobilesdk:ios:create --help
+-> sf mobilesdk:ios:create --help
 create an iOS native mobile application
 
 USAGE
-  $ sfdx mobilesdk:ios:create
+  $ sf mobilesdk ios create -n <value> -k <value> -o <value> [-t <value>] [-d
+    <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -t, --apptype=apptype            application type (native_swift or native,
-                                   leave empty for native_swift)
+FLAGS
+  -d, --outputdir=<value>     output directory (leave empty for current
+                              directory)
+  -k, --packagename=<value>   (required) app package identifier (e.g.
+                              com.mycompany.myapp)
+  -n, --appname=<value>       (required) application name
+  -o, --organization=<value>  (required) organization name (your
+                              company's/organization's name)
+  -t, --apptype=<value>       application type (native_swift or native, leave
+                              empty for native_swift)
 
 DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
+  create an iOS native mobile application
+
+  This command initiates creation of a new app based on the standard Mobile SDK
   template.
 
 ```
 
 ### List available native iOS templates
 ```
--> sfdx mobilesdk:ios:listtemplates --help
+-> sf mobilesdk:ios:listtemplates --help
 list available Mobile SDK templates to create an iOS native mobile application
 
 USAGE
-  $ sfdx mobilesdk:ios:listtemplates
+  $ sf mobilesdk ios listtemplates
 
 DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
+  list available Mobile SDK templates to create an iOS native mobile application
+
+  This command displays the list of available Mobile SDK templates. You can copy
   repo paths from the output for use with the createwithtemplate command.
 
 ```
 
 ### Create iOS application from template
 ```
--> sfdx mobilesdk:ios:createwithtemplate --help
+-> sf mobilesdk:ios:createwithtemplate --help
 create an iOS native mobile application from a template
 
 USAGE
-  $ sfdx mobilesdk:ios:createwithtemplate
+  $ sf mobilesdk ios createwithtemplate -r <value> -n <value> -k <value> -o <value> [-d
+    <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
+FLAGS
+  -d, --outputdir=<value>        output directory (leave empty for current
+                                 directory)
+  -k, --packagename=<value>      (required) app package identifier (e.g.
+                                 com.mycompany.myapp)
+  -n, --appname=<value>          (required) application name
+  -o, --organization=<value>     (required) organization name (your
+                                 company's/organization's name)
+  -r, --templaterepouri=<value>  (required) template repo URI or Mobile SDK
+                                 template name
 
 DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
+  create an iOS native mobile application from a template
+
+  This command initiates creation of a new app based on the Mobile SDK template
+  that you specify. The template can be a specialized app for your app type that
+  Mobile SDK provides, or your own custom app that you've configured to use as a
+  template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.met
+  a/mobile_sdk/ios_new_project_template.htm for information on custom templates.
 
 ```
 
 ### Check store or syncs config
 ```
--> sfdx mobilesdk:ios:checkconfig --help
+-> sf mobilesdk:ios:checkconfig --help
 validate store or syncs configuration
 
 USAGE
-  $ sfdx mobilesdk:ios:checkconfig
+  $ sf mobilesdk ios checkconfig -p <value> -t <value>
 
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
+FLAGS
+  -p, --configpath=<value>  (required) path to store or syncs config to validate
+  -t, --configtype=<value>  (required) type of config to validate (store or
+                            syncs)
 
 DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
+  validate store or syncs configuration
+
+  This command checks whether the given store or syncs configuration is valid
   according to its JSON schema.
 
 ```
@@ -170,118 +155,118 @@ DESCRIPTION
 ## Create a native Android application 
 ### Help for Android
 ```
--> sfdx mobilesdk:android --help
+-> sf mobilesdk:android --help
 create an Android native mobile application
 
 USAGE
-  $ sfdx mobilesdk:android:COMMAND
+  $ sf mobilesdk android COMMAND
 
 COMMANDS
-  mobilesdk:android:checkconfig         validate store or syncs configuration
-  mobilesdk:android:create              create an Android native mobile
+  mobilesdk android checkconfig         validate store or syncs configuration
+  mobilesdk android create              create an Android native mobile
                                         application
-  mobilesdk:android:createwithtemplate  create an Android native mobile
+  mobilesdk android createwithtemplate  create an Android native mobile
                                         application from a template
-  mobilesdk:android:listtemplates       list available Mobile SDK templates to
+  mobilesdk android listtemplates       list available Mobile SDK templates to
                                         create an Android native mobile
                                         application
-  mobilesdk:android:version             show version of Mobile SDK
+  mobilesdk android version             show version of Mobile SDK
 
 ```
 
 ### Create Java (native) or Kotlin (native_kotlin) application
 ```
--> sfdx mobilesdk:android:create --help
+-> sf mobilesdk:android:create --help
 create an Android native mobile application
 
 USAGE
-  $ sfdx mobilesdk:android:create
+  $ sf mobilesdk android create -n <value> -k <value> -o <value> [-t <value>] [-d
+    <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -t, --apptype=apptype            application type (native_kotlin or native,
-                                   leave empty for native_kotlin)
+FLAGS
+  -d, --outputdir=<value>     output directory (leave empty for current
+                              directory)
+  -k, --packagename=<value>   (required) app package identifier (e.g.
+                              com.mycompany.myapp)
+  -n, --appname=<value>       (required) application name
+  -o, --organization=<value>  (required) organization name (your
+                              company's/organization's name)
+  -t, --apptype=<value>       application type (native_kotlin or native, leave
+                              empty for native_kotlin)
 
 DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
+  create an Android native mobile application
+
+  This command initiates creation of a new app based on the standard Mobile SDK
   template.
 
 ```
 
 ### List available native Android templates
 ```
--> sfdx mobilesdk:android:listtemplates --help
+-> sf mobilesdk:android:listtemplates --help
 list available Mobile SDK templates to create an Android native mobile application
 
 USAGE
-  $ sfdx mobilesdk:android:listtemplates
+  $ sf mobilesdk android listtemplates
 
 DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
+  list available Mobile SDK templates to create an Android native mobile
+  application
+
+  This command displays the list of available Mobile SDK templates. You can copy
   repo paths from the output for use with the createwithtemplate command.
 
 ```
 
 ### Create Android application from template
 ```
--> sfdx mobilesdk:android:createwithtemplate --help
+-> sf mobilesdk:android:createwithtemplate --help
 create an Android native mobile application from a template
 
 USAGE
-  $ sfdx mobilesdk:android:createwithtemplate
+  $ sf mobilesdk android createwithtemplate -r <value> -n <value> -k <value> -o <value> [-d
+    <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
+FLAGS
+  -d, --outputdir=<value>        output directory (leave empty for current
+                                 directory)
+  -k, --packagename=<value>      (required) app package identifier (e.g.
+                                 com.mycompany.myapp)
+  -n, --appname=<value>          (required) application name
+  -o, --organization=<value>     (required) organization name (your
+                                 company's/organization's name)
+  -r, --templaterepouri=<value>  (required) template repo URI or Mobile SDK
+                                 template name
 
 DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
+  create an Android native mobile application from a template
+
+  This command initiates creation of a new app based on the Mobile SDK template
+  that you specify. The template can be a specialized app for your app type that
+  Mobile SDK provides, or your own custom app that you've configured to use as a
+  template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.met
+  a/mobile_sdk/ios_new_project_template.htm for information on custom templates.
 
 ```
 
 ### Check store or syncs config
 ```
--> sfdx mobilesdk:android:checkconfig --help
+-> sf mobilesdk:android:checkconfig --help
 validate store or syncs configuration
 
 USAGE
-  $ sfdx mobilesdk:android:checkconfig
+  $ sf mobilesdk android checkconfig -p <value> -t <value>
 
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
+FLAGS
+  -p, --configpath=<value>  (required) path to store or syncs config to validate
+  -t, --configtype=<value>  (required) type of config to validate (store or
+                            syncs)
 
 DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
+  validate store or syncs configuration
+
+  This command checks whether the given store or syncs configuration is valid
   according to its JSON schema.
 
 ```
@@ -289,130 +274,123 @@ DESCRIPTION
 ## Create an hybrid application 
 ### Help for hybrid
 ```
--> sfdx mobilesdk:hybrid --help
+-> sf mobilesdk:hybrid --help
 create a hybrid mobile application
 
 USAGE
-  $ sfdx mobilesdk:hybrid:COMMAND
+  $ sf mobilesdk hybrid COMMAND
 
 COMMANDS
-  mobilesdk:hybrid:checkconfig         validate store or syncs configuration
-  mobilesdk:hybrid:create              create a hybrid mobile application
-  mobilesdk:hybrid:createwithtemplate  create a hybrid mobile application from a
+  mobilesdk hybrid checkconfig         validate store or syncs configuration
+  mobilesdk hybrid create              create a hybrid mobile application
+  mobilesdk hybrid createwithtemplate  create a hybrid mobile application from a
                                        template
-  mobilesdk:hybrid:listtemplates       list available Mobile SDK templates to
+  mobilesdk hybrid listtemplates       list available Mobile SDK templates to
                                        create a hybrid mobile application
-  mobilesdk:hybrid:version             show version of Mobile SDK
+  mobilesdk hybrid version             show version of Mobile SDK
 
 ```
 
 ### Create hybrid application
 ```
--> sfdx mobilesdk:hybrid:create --help
+-> sf mobilesdk:hybrid:create --help
 create a hybrid mobile application
 
 USAGE
-  $ sfdx mobilesdk:hybrid:create
+  $ sf mobilesdk hybrid create -p <value> -n <value> -k <value> -o <value> [-t
+    <value>] [-s <value>] [-d <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -p, --platform=platform          (required) comma-separated list of platforms
-                                   (ios, android)
-
-  -s, --startpage=startpage        app start page (the start page of your remote
-                                   app; required for hybrid_remote apps only)
-
-  -t, --apptype=apptype            application type (hybrid_local or
-                                   hybrid_remote or hybrid_lwc, leave empty for
-                                   hybrid_local)
+FLAGS
+  -d, --outputdir=<value>     output directory (leave empty for current
+                              directory)
+  -k, --packagename=<value>   (required) app package identifier (e.g.
+                              com.mycompany.myapp)
+  -n, --appname=<value>       (required) application name
+  -o, --organization=<value>  (required) organization name (your
+                              company's/organization's name)
+  -p, --platform=<value>      (required) comma-separated list of platforms (ios,
+                              android)
+  -s, --startpage=<value>     app start page (the start page of your remote app;
+                              required for hybrid_remote apps only)
+  -t, --apptype=<value>       application type (hybrid_local or hybrid_remote or
+                              hybrid_lwc, leave empty for hybrid_local)
 
 DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
+  create a hybrid mobile application
+
+  This command initiates creation of a new app based on the standard Mobile SDK
   template.
 
 ```
 
 ### List available hybrid templates
 ```
--> sfdx mobilesdk:hybrid:listtemplates --help
+-> sf mobilesdk:hybrid:listtemplates --help
 list available Mobile SDK templates to create a hybrid mobile application
 
 USAGE
-  $ sfdx mobilesdk:hybrid:listtemplates
+  $ sf mobilesdk hybrid listtemplates
 
 DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
+  list available Mobile SDK templates to create a hybrid mobile application
+
+  This command displays the list of available Mobile SDK templates. You can copy
   repo paths from the output for use with the createwithtemplate command.
 
 ```
 
 ### Create hybrid application from template
 ```
--> sfdx mobilesdk:hybrid:createwithtemplate --help
+-> sf mobilesdk:hybrid:createwithtemplate --help
 create a hybrid mobile application from a template
 
 USAGE
-  $ sfdx mobilesdk:hybrid:createwithtemplate
+  $ sf mobilesdk hybrid createwithtemplate -p <value> -r <value> -n <value> -k <value> -o <value>
+    [-s <value>] [-d <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -p, --platform=platform                (required) comma-separated list of
-                                         platforms (ios, android)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
-
-  -s, --startpage=startpage              app start page (the start page of your
-                                         remote app; required for hybrid_remote
-                                         apps only)
+FLAGS
+  -d, --outputdir=<value>        output directory (leave empty for current
+                                 directory)
+  -k, --packagename=<value>      (required) app package identifier (e.g.
+                                 com.mycompany.myapp)
+  -n, --appname=<value>          (required) application name
+  -o, --organization=<value>     (required) organization name (your
+                                 company's/organization's name)
+  -p, --platform=<value>         (required) comma-separated list of platforms
+                                 (ios, android)
+  -r, --templaterepouri=<value>  (required) template repo URI or Mobile SDK
+                                 template name
+  -s, --startpage=<value>        app start page (the start page of your remote
+                                 app; required for hybrid_remote apps only)
 
 DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
+  create a hybrid mobile application from a template
+
+  This command initiates creation of a new app based on the Mobile SDK template
+  that you specify. The template can be a specialized app for your app type that
+  Mobile SDK provides, or your own custom app that you've configured to use as a
+  template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.met
+  a/mobile_sdk/ios_new_project_template.htm for information on custom templates.
 
 ```
 
 ### Check store or syncs config
 ```
--> sfdx mobilesdk:hybrid:checkconfig --help
+-> sf mobilesdk:hybrid:checkconfig --help
 validate store or syncs configuration
 
 USAGE
-  $ sfdx mobilesdk:hybrid:checkconfig
+  $ sf mobilesdk hybrid checkconfig -p <value> -t <value>
 
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
+FLAGS
+  -p, --configpath=<value>  (required) path to store or syncs config to validate
+  -t, --configtype=<value>  (required) type of config to validate (store or
+                            syncs)
 
 DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
+  validate store or syncs configuration
+
+  This command checks whether the given store or syncs configuration is valid
   according to its JSON schema.
 
 ```
@@ -420,122 +398,124 @@ DESCRIPTION
 ## Create a React Native application
 ### Help for React Native
 ```
--> sfdx mobilesdk:reactnative --help
+-> sf mobilesdk:reactnative --help
 create a React Native mobile application
 
 USAGE
-  $ sfdx mobilesdk:reactnative:COMMAND
+  $ sf mobilesdk reactnative COMMAND
 
 COMMANDS
-  mobilesdk:reactnative:checkconfig         validate store or syncs
+  mobilesdk reactnative checkconfig         validate store or syncs
                                             configuration
-  mobilesdk:reactnative:create              create a React Native mobile
+  mobilesdk reactnative create              create a React Native mobile
                                             application
-  mobilesdk:reactnative:createwithtemplate  create a React Native mobile
+  mobilesdk reactnative createwithtemplate  create a React Native mobile
                                             application from a template
-  mobilesdk:reactnative:listtemplates       list available Mobile SDK templates
+  mobilesdk reactnative listtemplates       list available Mobile SDK templates
                                             to create a React Native mobile
                                             application
-  mobilesdk:reactnative:version             show version of Mobile SDK
+  mobilesdk reactnative version             show version of Mobile SDK
 
 ```
 
 ### Create React Native application
 ```
--> sfdx mobilesdk:reactnative:create --help
+-> sf mobilesdk:reactnative:create --help
 create a React Native mobile application
 
 USAGE
-  $ sfdx mobilesdk:reactnative:create
+  $ sf mobilesdk reactnative create -p <value> -n <value> -k <value> -o <value> [-t
+    <value>] [-d <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir        output directory (leave empty for current
-                                   directory)
-
-  -k, --packagename=packagename    (required) app package identifier (e.g.
-                                   com.mycompany.myapp)
-
-  -n, --appname=appname            (required) application name
-
-  -o, --organization=organization  (required) organization name (your
-                                   company's/organization's name)
-
-  -p, --platform=platform          (required) comma-separated list of platforms
-                                   (ios, android)
+FLAGS
+  -d, --outputdir=<value>     output directory (leave empty for current
+                              directory)
+  -k, --packagename=<value>   (required) app package identifier (e.g.
+                              com.mycompany.myapp)
+  -n, --appname=<value>       (required) application name
+  -o, --organization=<value>  (required) organization name (your
+                              company's/organization's name)
+  -p, --platform=<value>      (required) comma-separated list of platforms (ios,
+                              android)
+  -t, --apptype=<value>       application type (react_native_typescript or
+                              react_native, leave empty for
+                              react_native_typescript)
 
 DESCRIPTION
-  This command initiates creation of a new app based on the standard Mobile SDK 
+  create a React Native mobile application
+
+  This command initiates creation of a new app based on the standard Mobile SDK
   template.
 
 ```
 
 ### List available React Native templates
 ```
--> sfdx mobilesdk:reactnative:listtemplates --help
+-> sf mobilesdk:reactnative:listtemplates --help
 list available Mobile SDK templates to create a React Native mobile application
 
 USAGE
-  $ sfdx mobilesdk:reactnative:listtemplates
+  $ sf mobilesdk reactnative listtemplates
 
 DESCRIPTION
-  This command displays the list of available Mobile SDK templates. You can copy 
+  list available Mobile SDK templates to create a React Native mobile
+  application
+
+  This command displays the list of available Mobile SDK templates. You can copy
   repo paths from the output for use with the createwithtemplate command.
 
 ```
 
 ### Create React Native application from template
 ```
--> sfdx mobilesdk:reactnative:createwithtemplate --help
+-> sf mobilesdk:reactnative:createwithtemplate --help
 create a React Native mobile application from a template
 
 USAGE
-  $ sfdx mobilesdk:reactnative:createwithtemplate
+  $ sf mobilesdk reactnative createwithtemplate -p <value> -r <value> -n <value> -k <value> -o <value>
+    [-d <value>]
 
-OPTIONS
-  -d, --outputdir=outputdir              output directory (leave empty for
-                                         current directory)
-
-  -k, --packagename=packagename          (required) app package identifier (e.g.
-                                         com.mycompany.myapp)
-
-  -n, --appname=appname                  (required) application name
-
-  -o, --organization=organization        (required) organization name (your
-                                         company's/organization's name)
-
-  -p, --platform=platform                (required) comma-separated list of
-                                         platforms (ios, android)
-
-  -r, --templaterepouri=templaterepouri  (required) template repo URI or Mobile
-                                         SDK template name
+FLAGS
+  -d, --outputdir=<value>        output directory (leave empty for current
+                                 directory)
+  -k, --packagename=<value>      (required) app package identifier (e.g.
+                                 com.mycompany.myapp)
+  -n, --appname=<value>          (required) application name
+  -o, --organization=<value>     (required) organization name (your
+                                 company's/organization's name)
+  -p, --platform=<value>         (required) comma-separated list of platforms
+                                 (ios, android)
+  -r, --templaterepouri=<value>  (required) template repo URI or Mobile SDK
+                                 template name
 
 DESCRIPTION
-  This command initiates creation of a new app based on the Mobile SDK template 
-  that you specify. The template can be a specialized app for your app type that 
-  Mobile SDK provides, or your own custom app that you've configured to use as a 
-  template. See 
-  https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/i
-  os_new_project_template.htm for information on custom templates.
+  create a React Native mobile application from a template
+
+  This command initiates creation of a new app based on the Mobile SDK template
+  that you specify. The template can be a specialized app for your app type that
+  Mobile SDK provides, or your own custom app that you've configured to use as a
+  template. See https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.met
+  a/mobile_sdk/ios_new_project_template.htm for information on custom templates.
 
 ```
 
 ### Check store or syncs config
 ```
--> sfdx mobilesdk:reactnative:checkconfig --help
+-> sf mobilesdk:reactnative:checkconfig --help
 validate store or syncs configuration
 
 USAGE
-  $ sfdx mobilesdk:reactnative:checkconfig
+  $ sf mobilesdk reactnative checkconfig -p <value> -t <value>
 
-OPTIONS
-  -p, --configpath=configpath  (required) path to store or syncs config to
-                               validate
-
-  -t, --configtype=configtype  (required) type of config to validate (store or
-                               syncs)
+FLAGS
+  -p, --configpath=<value>  (required) path to store or syncs config to validate
+  -t, --configtype=<value>  (required) type of config to validate (store or
+                            syncs)
 
 DESCRIPTION
-  This command checks whether the given store or syncs configuration is valid 
+  validate store or syncs configuration
+
+  This command checks whether the given store or syncs configuration is valid
   according to its JSON schema.
 
 ```

--- a/sfdx/generate_readme.sh
+++ b/sfdx/generate_readme.sh
@@ -18,25 +18,11 @@ cat <<EOT > README.md
 
 A plugin for the Salesforce CLI to create mobile applications to interface with the [Salesforce Platform](http://www.salesforce.com/platform/overview/), leveraging the [Salesforce Mobile SDK for iOS](https://github.com/forcedotcom/SalesforceMobileSDK-iOS) and the [Salesforce Mobile SDK for Android](https://github.com/forcedotcom/SalesforceMobileSDK-Android) repos.
 
-## Special Note Regarding SFDX and Oclif
-
-SFDX now supports the Heroku "O"pen "CLI" "F"ramework and sfdx-mobilesdk-plugin v7.1.0 has been updated to be compatible. The new plugin will run in both version 6 and version 7 instances of the SFDX cli. However, older versions of the mobilesdk plugin will not work in the Oclif version of the CLI. 
-
-If there is a need to use an older plugin one must first uninstall V7 of the CLI and install a V6 instance.
-
-To determine the latest version of v6 go here:
-
-https://www.npmjs.com/package/sfdx-cli?activeTab=versions
-
-The most reliable way to install a previous version of the CLI is via npm.
-
-\`npm install sfdx-cli@<V6 version from npmjs> -g\`
-
 ## Setup
 
 ### Install from source
 
-1. Install the SDFX CLI (https://developer.salesforce.com/tools/sfdxcli).
+1. Install the Salesforce CLI (https://developer.salesforce.com/tools/salesforcecli).
 
 2. Clone the repository: \`git clone git@github.com:forcedotcom/SalesforceMobileSDK-Package\`
 
@@ -44,61 +30,61 @@ The most reliable way to install a previous version of the CLI is via npm.
 
 4. Generate oclif command classes \`./sfdx/generate_oclif.js\`
 
-5. Link the plugin: \`sfdx plugins:link sfdx\`
+5. Link the plugin: \`sf plugins:link sfdx\`
 
 ### Install as plugin
 
-1. Install plugin: \`sfdx plugins:install sfdx-mobilesdk-plugin\`
+1. Install plugin: \`sf plugins:install sfdx-mobilesdk-plugin\`
 
 EOT
 
 print "## Help"
-run 'sfdx mobilesdk --help'
+run 'sf mobilesdk --help'
 print "## Create a native iOS application "
 print "### Help for iOS"
-run 'sfdx mobilesdk:ios --help'
+run 'sf mobilesdk:ios --help'
 print "### Create Objective-C (native) or Swift (native_swift) application"
-run 'sfdx mobilesdk:ios:create --help'
+run 'sf mobilesdk:ios:create --help'
 print "### List available native iOS templates"
-run 'sfdx mobilesdk:ios:listtemplates --help'
+run 'sf mobilesdk:ios:listtemplates --help'
 print "### Create iOS application from template"
-run 'sfdx mobilesdk:ios:createwithtemplate --help'
+run 'sf mobilesdk:ios:createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sfdx mobilesdk:ios:checkconfig --help'
+run 'sf mobilesdk:ios:checkconfig --help'
 
 print "## Create a native Android application "
 print "### Help for Android"
-run 'sfdx mobilesdk:android --help'
+run 'sf mobilesdk:android --help'
 print "### Create Java (native) or Kotlin (native_kotlin) application"
-run 'sfdx mobilesdk:android:create --help'
+run 'sf mobilesdk:android:create --help'
 print "### List available native Android templates"
-run 'sfdx mobilesdk:android:listtemplates --help'
+run 'sf mobilesdk:android:listtemplates --help'
 print "### Create Android application from template"
-run 'sfdx mobilesdk:android:createwithtemplate --help'
+run 'sf mobilesdk:android:createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sfdx mobilesdk:android:checkconfig --help'
+run 'sf mobilesdk:android:checkconfig --help'
 
 print "## Create an hybrid application "
 print "### Help for hybrid"
-run 'sfdx mobilesdk:hybrid --help'
+run 'sf mobilesdk:hybrid --help'
 print "### Create hybrid application"
-run 'sfdx mobilesdk:hybrid:create --help'
+run 'sf mobilesdk:hybrid:create --help'
 print "### List available hybrid templates"
-run 'sfdx mobilesdk:hybrid:listtemplates --help'
+run 'sf mobilesdk:hybrid:listtemplates --help'
 print "### Create hybrid application from template"
-run 'sfdx mobilesdk:hybrid:createwithtemplate --help'
+run 'sf mobilesdk:hybrid:createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sfdx mobilesdk:hybrid:checkconfig --help'
+run 'sf mobilesdk:hybrid:checkconfig --help'
 
 print "## Create a React Native application"
 print "### Help for React Native"
-run 'sfdx mobilesdk:reactnative --help'
+run 'sf mobilesdk:reactnative --help'
 print "### Create React Native application"
-run 'sfdx mobilesdk:reactnative:create --help'
+run 'sf mobilesdk:reactnative:create --help'
 print "### List available React Native templates"
-run 'sfdx mobilesdk:reactnative:listtemplates --help'
+run 'sf mobilesdk:reactnative:listtemplates --help'
 print "### Create React Native application from template"
-run 'sfdx mobilesdk:reactnative:createwithtemplate --help'
+run 'sf mobilesdk:reactnative:createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sfdx mobilesdk:reactnative:checkconfig --help'
+run 'sf mobilesdk:reactnative:checkconfig --help'
 

--- a/sfdx/generate_readme.sh
+++ b/sfdx/generate_readme.sh
@@ -30,11 +30,11 @@ A plugin for the Salesforce CLI to create mobile applications to interface with 
 
 4. Generate oclif command classes \`./sfdx/generate_oclif.js\`
 
-5. Link the plugin: \`sf plugins:link sfdx\`
+5. Link the plugin: \`sf plugins link sfdx\`
 
 ### Install as plugin
 
-1. Install plugin: \`sf plugins:install sfdx-mobilesdk-plugin\`
+1. Install plugin: \`sf plugins install sfdx-mobilesdk-plugin\`
 
 EOT
 
@@ -42,49 +42,49 @@ print "## Help"
 run 'sf mobilesdk --help'
 print "## Create a native iOS application "
 print "### Help for iOS"
-run 'sf mobilesdk:ios --help'
+run 'sf mobilesdk ios --help'
 print "### Create Objective-C (native) or Swift (native_swift) application"
-run 'sf mobilesdk:ios:create --help'
+run 'sf mobilesdk ios create --help'
 print "### List available native iOS templates"
-run 'sf mobilesdk:ios:listtemplates --help'
+run 'sf mobilesdk ios listtemplates --help'
 print "### Create iOS application from template"
-run 'sf mobilesdk:ios:createwithtemplate --help'
+run 'sf mobilesdk ios createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sf mobilesdk:ios:checkconfig --help'
+run 'sf mobilesdk ios checkconfig --help'
 
 print "## Create a native Android application "
 print "### Help for Android"
-run 'sf mobilesdk:android --help'
+run 'sf mobilesdk android --help'
 print "### Create Java (native) or Kotlin (native_kotlin) application"
-run 'sf mobilesdk:android:create --help'
+run 'sf mobilesdk android create --help'
 print "### List available native Android templates"
-run 'sf mobilesdk:android:listtemplates --help'
+run 'sf mobilesdk android listtemplates --help'
 print "### Create Android application from template"
-run 'sf mobilesdk:android:createwithtemplate --help'
+run 'sf mobilesdk android createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sf mobilesdk:android:checkconfig --help'
+run 'sf mobilesdk android checkconfig --help'
 
 print "## Create an hybrid application "
 print "### Help for hybrid"
-run 'sf mobilesdk:hybrid --help'
+run 'sf mobilesdk hybrid --help'
 print "### Create hybrid application"
-run 'sf mobilesdk:hybrid:create --help'
+run 'sf mobilesdk hybrid create --help'
 print "### List available hybrid templates"
-run 'sf mobilesdk:hybrid:listtemplates --help'
+run 'sf mobilesdk hybrid listtemplates --help'
 print "### Create hybrid application from template"
-run 'sf mobilesdk:hybrid:createwithtemplate --help'
+run 'sf mobilesdk hybrid createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sf mobilesdk:hybrid:checkconfig --help'
+run 'sf mobilesdk hybrid checkconfig --help'
 
 print "## Create a React Native application"
 print "### Help for React Native"
-run 'sf mobilesdk:reactnative --help'
+run 'sf mobilesdk reactnative --help'
 print "### Create React Native application"
-run 'sf mobilesdk:reactnative:create --help'
+run 'sf mobilesdk reactnative create --help'
 print "### List available React Native templates"
-run 'sf mobilesdk:reactnative:listtemplates --help'
+run 'sf mobilesdk reactnative listtemplates --help'
 print "### Create React Native application from template"
-run 'sf mobilesdk:reactnative:createwithtemplate --help'
+run 'sf mobilesdk reactnative createwithtemplate --help'
 print "### Check store or syncs config"
-run 'sf mobilesdk:reactnative:checkconfig --help'
+run 'sf mobilesdk reactnative checkconfig --help'
 

--- a/sfdx/package.json
+++ b/sfdx/package.json
@@ -1,7 +1,7 @@
 {
     "name": "sfdx-mobilesdk-plugin",
     "version": "12.0.0",
-    "description": "Sfdx plugin for creating mobile apps based on the Salesforce Mobile SDK",
+    "description": "Salesforce CLI plugin for creating mobile apps based on the Salesforce Mobile SDK",
     "keywords": [
         "mobilesdk",
         "salesforce",

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -68,8 +68,8 @@ module.exports = {
                 android: '12.0.1'
             }
         },
-        sfdx: {
-            checkCmd: 'sfdx -v',
+        sf: {
+            checkCmd: 'sf -v',
             minVersion: '2.0.0'
         }    
     },
@@ -117,7 +117,7 @@ module.exports = {
             purpose: 'a hybrid mobile application',
             dir: 'hybrid',
             platforms: ['ios', 'android'],
-            toolNames: ['git', 'node', 'npm', 'cordova', 'sfdx'],
+            toolNames: ['git', 'node', 'npm', 'cordova', 'sf'],
             appTypes: ['hybrid_local', 'hybrid_remote', 'hybrid_lwc'],
             appTypesToPath: {
                 'hybrid_local': 'HybridLocalTemplate',

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -70,7 +70,7 @@ module.exports = {
         },
         sfdx: {
             checkCmd: 'sfdx -v',
-            minVersion: '6.0.0'
+            minVersion: '2.0.0'
         }    
     },
 

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -90,7 +90,7 @@ function createHybridApp(config) {
     // Merge files from template into it
     if (utils.dirExists(path.join(webDir, SERVER_PROJECT_DIR))) {
         config.serverDir = path.join(config.projectDir, SERVER_PROJECT_DIR)
-        utils.runProcessThrowError('sfdx force:project:create -n ' + SERVER_PROJECT_DIR, config.projectDir);
+        utils.runProcessThrowError('sf force project create -n ' + SERVER_PROJECT_DIR, config.projectDir);
 
         // Copy cordova js to static resources
         for (var platform of config.platform.split(',')) {
@@ -273,11 +273,11 @@ function printNextStepsForServerProjectIfNeeded(projectPath) {
                             'Make sure to deploy it to your org before running your application.',
                             '',
                             'From ' + projectPath + ' do the following to setup a scratch org, push the server code:',
-                            '   - sfdx force:org:create -f server/config/project-scratch-def.json -a MyOrg',
+                            '   - sf force org create -f server/config/project-scratch-def.json -a MyOrg',
                             '   - cd server',
-                            '   - sfdx force:source:push -u MyOrg',
+                            '   - sf force source push -u MyOrg',
                             'You also need a password to login to the scratch org from the mobile app:',
-                            '   - sfdx force:user:password:generate -u MyOrg'                            
+                            '   - sf force user password generate -u MyOrg'                            
                             ]);
     }
 }

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -123,7 +123,8 @@ function getToolVersion(cmd) {
     var toolVersion;
     try {
 	 var result = runProcessThrowError(cmd, null, true /* return output */);
-        toolVersion = result.replace(/\r?\n|\r/, '').replace(/[^0-9\.]*/, '');
+        // Remove @salesforce/cli/ from the beginning of sf cli version.
+        toolVersion = result.replace(/\r?\n|\r/, '').replace(/[^0-9\.]*/, '').replace('@salesforce/cli/', '');
     }
     catch (error) {
         throw new Error(toolName + ' is required but could not be found. Please install ' + toolName + '.');


### PR DESCRIPTION
sfdx has been replaced by Salesforce CLI (which can be launched by calling `sf` or also `sfdx`).
sf is at v2 while the last sfdx was v7.