### PR TITLE
Most recent templates were not properly setup during dry run

### DIFF
--- a/release/setup_test_branches.js
+++ b/release/setup_test_branches.js
@@ -49,6 +49,7 @@ const testVersionDefault = VERSION
 const templatesPackageJsons = [
     './AndroidIDPTemplate/package.json',
     './AndroidNativeKotlinTemplate/package.json',
+    './AndroidNativeLoginTemplate/package.json',
     './AndroidNativeTemplate/package.json',
     './HybridLocalTemplate/package.json',
     './HybridLwcTemplate/package.json',
@@ -60,7 +61,9 @@ const templatesPackageJsons = [
     './ReactNativeTemplate/package.json',
     './ReactNativeTypeScriptTemplate/package.json',
     './iOSIDPTemplate/package.json',
+    './iOSNativeLoginTemplate/package.json',
     './iOSNativeSwiftEncryptedNotificationTemplate/package.json',
+    './iOSNativeSwiftPackageManagerTemplate/package.json',
     './iOSNativeSwiftTemplate/package.json',
     './iOSNativeTemplate/package.json'
 ]


### PR DESCRIPTION
`setup_test_branches.js` takes care of creating master2, dev2 branches that mirror master, dev in all the repos of the forked org.
It also makes sure the submodules and package.json point to the forked org (and not forcedotcom).
Most recent template's package.json were not updated causing test_force.js to fail during a dry run.