### PR TITLE
Ability to override sdk dependencies in forceios/forcedroid etc and test_force.js / also new test_force.js flag to do SPM update (locally)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 aliases:
 #  Xcode version announcments can be found here: https://discuss.circleci.com/c/announcements/
 #  Each post contains a full image manifest, including iOS runtimes, devices, CocoaPods version, etc.
-  - &latest-xcode    "15.3.0"
+  - &latest-xcode    "16.0.0"
   - &latest-android  "cimg/android:2024.07.1-node"
   - &invalid         ""
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - run: *setup
       - run:
           name: Building all ios native templates
-          command:  ./test/test_force.js --exit-on-failure --cli=forceios --spm-update
+          command:  ./test/test_force.js --exit-on-failure --cli=forceios
           when: always
 
   forceios-sfdx:
@@ -163,7 +163,7 @@ jobs:
       - run: *install-sfdx
       - run:
           name: Building all ios native templates with SFDX
-          command: ./test/test_force.js --exit-on-failure --cli=forceios --use-sfdx --spm-update
+          command: ./test/test_force.js --exit-on-failure --cli=forceios --use-sfdx
           when: always
 
   forcehybrid-ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - run: *setup
       - run:
           name: Building all ios native templates
-          command:  ./test/test_force.js --exit-on-failure --cli=forceios
+          command:  ./test/test_force.js --exit-on-failure --cli=forceios --spm-update
           when: always
 
   forceios-sfdx:
@@ -163,7 +163,7 @@ jobs:
       - run: *install-sfdx
       - run:
           name: Building all ios native templates with SFDX
-          command: ./test/test_force.js --exit-on-failure --cli=forceios --use-sfdx
+          command: ./test/test_force.js --exit-on-failure --cli=forceios --use-sfdx --spm-update
           when: always
 
   forcehybrid-ios:

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -268,7 +268,17 @@ module.exports = {
             required: false,
             type: 'string',
             hidden: true
-        }
+        },
+	sdkDependencies: {
+            name: 'sdkdependencies',
+            description: 'override sdk dependencies',
+            'char': 'd',
+            error: cli => val => 'Invalid value for sdk dependencies: \'' + val + '\'.',
+            validate: cli => val => /.*/.test(val),
+            required: false,
+            type: 'string',
+            hidden: true
+	},
     },
 
     commands: {
@@ -282,7 +292,8 @@ module.exports = {
                           cli.appTypes.indexOf('hybrid_remote') >=0 ? 'startPage' : null,
                           'outputDir',
                           'verbose',
-                          cli.name === 'forcehybrid' ? 'pluginRepoUri' : null
+                          cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
+			  'sdkDependencies'
                          ].filter(x=>x!=null),
             description: cli => 'create ' + cli.purpose,
             longDescription: cli => 'Create ' + cli.purpose + '.',
@@ -298,7 +309,8 @@ module.exports = {
                           cli.appTypes.indexOf('hybrid_remote') >=0 ? 'startPage' : null,
                           'outputDir',
                           'verbose',
-                          cli.name === 'forcehybrid' ? 'pluginRepoUri' : null
+                          cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
+			  'sdkDependencies'			  
                          ].filter(x=>x!=null),
             description: cli => 'create ' + cli.purpose + ' from a template',
             longDescription: cli => 'Create ' + cli.purpose + ' from a template.',

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -49,12 +49,15 @@ function main(args) {
     var usageRequested = parsedArgs.hasOwnProperty('usage');
     var useSfdxRequested = parsedArgs.hasOwnProperty('use-sfdx');
     var noPluginUpdate = parsedArgs.hasOwnProperty('no-plugin-update');
+    var spmUpdate = parsedArgs.hasOwnProperty('spm-update');
     var exitOnFailure = parsedArgs.hasOwnProperty('exit-on-failure');
     var chosenOperatingSystems = cleanSplit(parsedArgs.os, ',').map(function(s) { return s.toLowerCase(); });
     var templateRepoUri = parsedArgs.templaterepouri || '';
     var pluginRepoUri = parsedArgs.pluginrepouri || SDK.tools.cordova.pluginRepoUri;
+    var spmRepoUri = parsedArgs.spmrepouri || 'https://github.com/forcedotcom/SalesforceMobileSDK-iOS-SPM' // not in constants.js because it's for testing only
     var chosenAppTypes = cleanSplit(parsedArgs.apptype, ',');
     var chosenClis = cleanSplit(parsedArgs.cli, ',');
+    var sdkDependencies = parsedArgs.sdkdependencies;
 
     var testingWithOS = chosenOperatingSystems.length > 0;
     var testingWithClis = chosenClis.length > 0;
@@ -131,6 +134,17 @@ function main(args) {
         }
     }
 
+    // Clone spm repo and build it if spm-update requested
+    if (spmUpdate) {
+        var spmRepoDir = utils.cloneRepo(tmpDir, spmRepoUri);
+        utils.runProcessCatchError(`${spmRepoDir}/build_xcframeworks.sh`, 'Building xcframeworks for SPM');
+        // Prepare sdk dependencies override that points to local clone of SPM repo
+        if (!sdkDependencies) {
+            sdkDependencies = {}
+        }
+        sdkDependencies = {"SalesforceMobileSDK-iOS-SPM": spmRepoDir}
+    }
+
     // Set exit on failure to true
     if (exitOnFailure) {
         utils.setExitOnFailure(true);
@@ -146,7 +160,7 @@ function main(args) {
                 for (var k=0; k<template.platforms.length; k++) {
                     var os = template.platforms[k];
                     if (chosenOperatingSystems.length == 0 || chosenOperatingSystems.indexOf(os) >= 0) {
-                        createCompileApp(tmpDir, os, template.appType, template.path, pluginRepoUri, useSfdxRequested);
+                        createCompileApp(tmpDir, os, template.appType, template.path, pluginRepoUri, useSfdxRequested, sdkDependencies);
                     }
                 }
             }
@@ -158,14 +172,14 @@ function main(args) {
             if (testingWithAppType) {
                 for (var j=0; j<chosenAppTypes.length; j++) {
                     var appType = chosenAppTypes[j];
-                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested);
+                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested, sdkDependencies);
                 }
             }
 
             if (testingWithTemplate) {
                 // NB: chosenAppTypes[0] is appType from template
                 var appType = chosenAppTypes.length > 0 ? chosenAppTypes[0] : [templateHelper.getAppTypeFromTemplate(templateRepoUri)];
-                createCompileApp(tmpDir, os, appType, templateRepoUri, pluginRepoUri, useSfdxRequested);
+                createCompileApp(tmpDir, os, appType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies);
             }
         }
     }
@@ -185,6 +199,9 @@ function shortUsage(exitCode) {
     utils.logInfo('    [--exit-on-failure]', COLOR.magenta);
     utils.logInfo('    [--pluginrepouri=PLUGIN_REPO_URI (Defaults to uri in shared/constants.js)]', COLOR.magenta);
     utils.logInfo('    [--no-plugin-update]', COLOR.magenta);
+    utils.logInfo('    [--spm-update]', COLOR.magenta);
+    utils.logInfo('    [--spmrepouri=SPM_REPO_URI]', COLOR.magenta);
+    utils.logInfo('    [--sdkdependencies=SDK_DEPDENDENCIES_OVERRIDE]', COLOR.magenta);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);
@@ -282,7 +299,7 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
 //
 // Create and compile app
 //
-function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested) {
+function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies) {
     var execArgs = '';
     var isNative = actualAppType == APP_TYPE.native || actualAppType == APP_TYPE.native_swift || actualAppType == APP_TYPE.native_kotlin; 
     var isReactNative = actualAppType == APP_TYPE.react_native || actualAppType == APP_TYPE.react_native_typescript;
@@ -343,6 +360,10 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
         + (isHybridRemote ? ' --startpage=' + defaultStartPage : '')
         + (isHybrid && pluginRepoUri ? ' --pluginrepouri=' + pluginRepoUri : '');
 
+    if (sdkDependencies) {
+        execArgs += ' --sdkDependencies=' + JSON.stringify(sdkDependencies).replace(/"/g, '\\"');
+    }
+
     // Generation
     var generationSucceeded = utils.runProcessCatchError(execPath + execArgs, 'GENERATING ' + target);
 
@@ -377,11 +398,11 @@ function buildForiOS(target, workspaceDir, appName) {
     const workspacePath = path.join(workspaceDir, appName + '.xcworkspace');
     const projectPath = path.join(workspaceDir, appName + '.xcodeproj');
     const buildTarget = existsSync(workspacePath)
-	  ? `-workspace ${workspacePath} -scheme ${appName}`
-	  : `-project ${projectPath}`;
+          ? `-workspace ${workspacePath} -scheme ${appName}`
+          : `-project ${projectPath}`;
     
     utils.runProcessCatchError(`xcodebuild ${buildTarget} clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`,
-			       `COMPILING ${target}`);
+                               `COMPILING ${target}`);
 }
 
 function buildForAndroid(target, workspaceDir) {
@@ -528,4 +549,4 @@ function computePackageName(os, actualAppType, appName) {
     var isHybrid = actualAppType === APP_TYPE.hybrid_local || actualAppType === APP_TYPE.hybrid_remote;
     return 'com.salesforce' + (os === OS.ios && !isHybrid ? '' : '.' + appName);
 }
-    
+


### PR DESCRIPTION
## New hidden arg for forceios/forcedroid/etc to override sdk dependencies
It's also exposed as a new optional argument for `test_force.js`.

Use SDK dependencies override if you need to generate/build a template pointing to some fork/branch of Mobile SDK. To do that before, you would have to change the package.json of the template in your fork, check it in and then run test_force.js with templaterepouri pointing to your fork.

### Example
To build the template using the forked Salesforce Mobile SDK iOS repo pass the following:
```
--sdkdependencies={\"SalesforceMobileSDK-iOS\":\"https://github.com/somefork/SalesforceMobileSDK-iOS#somebranch\"}
```

## New test_force flag to do spm update (locally)
There is also a new flag spm-update for `test_force.js`. When provided the SPM repo is cloned and build locally and then the CLIs is invoked with SalesforceMobileSDK-iOS-SPM pointing to the local directory (using the sdk dependencies override just described). That way we can make sure that our SPM template generates and builds with the latest iOS code without having to build and check in the `xcframeworks` (which we only do at release time).

### Example
To generate/build SPM template with `xcframeworks` compiled from latest code do:
```shell
./test/test_force.js --templaterepouri=https://github.com/forcedotcom/SalesforceMobileSDK-Templates/iOSNativeSwiftPackageManagerTemplate#dev --os=ios --spm-update
```