### PR TITLE
Not letting xcodebuild pick the destination randomly

### DIFF
--- a/test/test_force.js
+++ b/test/test_force.js
@@ -401,7 +401,7 @@ function buildForiOS(target, workspaceDir, appName) {
           ? `-workspace ${workspacePath} -scheme ${appName}`
           : `-project ${projectPath}`;
     
-    utils.runProcessCatchError(`xcodebuild ${buildTarget} clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`,
+    utils.runProcessCatchError(`xcodebuild ${buildTarget} clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -destination generic/platform=iOS`,
                                `COMPILING ${target}`);
 }
 


### PR DESCRIPTION
Otherwise MobileSyncExplorerSwift was not compiling because a catalyst destination was used but. RecentContactsExtension does not compile there:
```
!FAILURE! COMPILING native_swift app for ios based on template MobileSyncExplorerSwift (dev)
Command failed: xcodebuild -workspace /Users/distiller/SalesforceMobileSDK-Package/tmp20241007T230359.281/iosmobilesyncexplorerswift/iosmobilesyncexplorerswift.xcworkspace -scheme iosmobilesyncexplorerswift clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:0000FE00-8D8861F646F3907A, name:My Mac }
...
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:0000FE00-8D8861F646F3907A, name:My Mac }
...
** BUILD FAILED **

The following build commands failed:
        EmitSwiftModule normal arm64 (in target 'RecentContactsExtension' from project 'iosmobilesyncexplorerswift')
        SwiftEmitModule normal arm64 Emitting\ module\ for\ RecentContactsExtension (in target 'RecentContactsExtension' from project 'iosmobilesyncexplorerswift')
        SwiftCompile normal arm64 Compiling\ RecentContacts.swift,\ ContactHelpers.swift /Users/distiller/SalesforceMobileSDK-Package/tmp20241007T230359.281/iosmobilesyncexplorerswift/RecentContacts/RecentContacts.swift /Users/distiller/SalesforceMobileSDK-Package/tmp20241007T230359.281/iosmobilesyncexplorerswift/iosmobilesyncexplorerswift/Helpers/ContactHelpers.swift (in target 'RecentContactsExtension' from project 'iosmobilesyncexplorerswift')
        Building workspace iosmobilesyncexplorerswift with scheme iosmobilesyncexplorerswift
(4 failures)
```