### PR TITLE
Update the listTemplates command to accept a template repo uri parameter

### DIFF
--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -126,7 +126,7 @@ function listTemplates(cli, commandLineArgs) {
     if (commandLineArgs && commandLineArgs.length > 0) {
         try {
             var argsMap = commandLineUtils.parseArgs(commandLineArgs);
-            templateSource = argsMap[SDK.args.templateSource && SDK.args.templateSource.name];
+            templateSource = argsMap[SDK.args.templateSource.name];
             templateRepoUri = argsMap[SDK.args.templateRepoUri.name];
         } catch (error) {
             // If argument parsing fails, continue without templateRepoUri
@@ -165,8 +165,8 @@ function usage(cli) {
 
     logInfo('\n' + cliName + ': Tool for building ' + cli.purpose + ' using Salesforce Mobile SDK', COLOR.cyan);
     logInfo('\nUsage:\n', COLOR.cyan);
-    for (var i = 0; i < cli.commands.length; i++) {
-        if (i > 0) {
+    for (var i=0; i<cli.commands.length; i++) {
+        if (i>0) {
             logInfo('\n OR \n', COLOR.cyan);
         }
         var commandName = cli.commands[i];

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -147,18 +147,12 @@ function listTemplates(cli, commandLineArgs) {
     for (var i = 0; i < applicableTemplates.length; i++) {
         var template = applicableTemplates[i];
         logInfo((i + 1) + ') ' + template.description, COLOR.cyan);
-        // If using custom repository, include it in the command
-        var templateUri = template.path;
-        if (source) {
-            // Parse the repository URI to separate repo and branch (reuse utils)
-            var parsed = separateRepoUrlPathBranch(source);
-            var repoUrl = parsed.repo;
-            var branch = parsed.branch;
-            var includeBranch = source.indexOf('#') !== -1 && !!branch;
-            // Format: repository/template-path[#branch]
-            templateUri = repoUrl + '/' + template.path + (includeBranch ? ('#' + branch) : '');
-        }
-        logInfo(cliName + ' ' + SDK.commands.createwithtemplate.name + ' --' + SDK.args.templateRepoUri.name + '=' + templateUri, COLOR.magenta);
+        // Always recommend using --templatesource and --template
+        var sourceForCommand = source || SDK.templatesRepoUri;
+        var command = cliName + ' ' + SDK.commands.createwithtemplate.name
+            + ' --' + SDK.args.templateSource.name + '=' + sourceForCommand
+            + ' --' + SDK.args.template.name + '=' + template.path;
+        logInfo(command, COLOR.magenta);
     }
     logInfo('');
 }

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -121,23 +121,26 @@ function printArgs(cli, commandName) {
 function listTemplates(cli, commandLineArgs) {
     var cliName = cli.name;
 
-    // Parse command line arguments to extract templateRepoUri
+    // Parse command line arguments to extract templatesource or templaterepouri
+    var templateSource = null;
     var templateRepoUri = null;
     if (commandLineArgs && commandLineArgs.length > 0) {
         try {
             var argsMap = commandLineUtils.parseArgs(commandLineArgs);
+            templateSource = argsMap[SDK.args.templateSource && SDK.args.templateSource.name];
             templateRepoUri = argsMap[SDK.args.templateRepoUri.name];
         } catch (error) {
             // If argument parsing fails, continue without templateRepoUri
         }
     }
 
-    var applicableTemplates = getTemplates(cli, templateRepoUri);
+    var source = templateSource || templateRepoUri;
+    var applicableTemplates = getTemplates(cli, source);
 
     // Show which template repository is being used
-    if (templateRepoUri) {
+    if (source) {
         logInfo('\nAvailable templates from custom repository:\n', COLOR.cyan);
-        logInfo('Repository: ' + templateRepoUri, COLOR.cyan);
+        logInfo('Repository: ' + source, COLOR.cyan);
     } else {
         logInfo('\nAvailable templates:\n', COLOR.cyan);
     }
@@ -147,9 +150,9 @@ function listTemplates(cli, commandLineArgs) {
         logInfo((i + 1) + ') ' + template.description, COLOR.cyan);
         // If using custom repository, include it in the command
         var templateUri = template.path;
-        if (templateRepoUri) {
+        if (source) {
             // Parse the repository URI to separate repo and branch
-            var repoParts = templateRepoUri.split('#');
+            var repoParts = source.split('#');
             var repoUrl = repoParts[0];
             var branch = repoParts.length > 1 ? repoParts[1] : '';
             // Format: repository/template-path#branch

--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -44,20 +44,22 @@ function getArgsExpanded(cli, commandName) {
     var argNames = applyCli(SDK.commands[commandName].args, cli);
     return argNames
         .map(argName => SDK.args[argName])
-        .map(arg => ({
-            name: arg.name,
-            'char': arg.char,
-            description: applyCli(arg.description, cli),
-            longDescription: applyCli(arg.longDescription, cli),
-            prompt: applyCli(arg.prompt, cli),
-            error: applyCli(arg.error, cli),
-            validate: applyCli(arg.validate, cli),
-            promptIf: arg.promptIf,
-            required: arg.required === undefined ? true : arg.required,
-            hasValue: arg.hasValue === undefined ? true : arg.hasValue,
-            hidden: applyCli(arg.hidden, cli),
-            type: arg.type
-        }));
+        .map(arg => 
+            ({
+                name: arg.name,
+                'char': arg.char,
+                description: applyCli(arg.description, cli),
+                longDescription: applyCli(arg.longDescription, cli),
+                prompt: applyCli(arg.prompt, cli),
+                error: applyCli(arg.error, cli),
+                validate: applyCli(arg.validate, cli),
+                promptIf: arg.promptIf,
+                required: arg.required === undefined ? true : arg.required,
+                hasValue: arg.hasValue === undefined ? true : arg.hasValue,
+                hidden: applyCli(arg.hidden, cli),
+                type: arg.type
+            })
+        );
 
 }
 

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -183,6 +183,9 @@ module.exports = {
             prompt: 'Enter git URL or local path to your templates suite:',
             error: cli => val => 'Invalid value for template source: \'' + val + '\'.',
             validate: cli => val => /\S+/.test(val),
+            // Do not prompt for this optional flag during interactive flows
+            // Tests and most users will not provide it; when provided explicitly, no prompt is needed
+            promptIf: otherArgs => false,
             required: false,
             type: 'string'
         },
@@ -194,6 +197,8 @@ module.exports = {
             prompt: 'Enter the template name from your template source:',
             error: cli => val => 'Invalid value for template: \'' + val + '\'.',
             validate: cli => val => /\S+/.test(val),
+            // Only prompt for template when a templatesource is provided
+            promptIf: otherArgs => !!otherArgs.templatesource,
             required: false,
             type: 'string'
         },

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -171,6 +171,30 @@ module.exports = {
             prompt: 'Enter URI of repo containing template application or a Mobile SDK template name:',
             error: cli => val => 'Invalid value for template repo uri: \'' + val + '\'.',
             validate: cli => val => /^\S+$/.test(val),
+            promptIf: otherArgs => !otherArgs.templatesource,
+            required: false,
+            type: 'string'
+        },
+        templateSource: {
+            name: 'templatesource',
+            'char': 'S',
+            description: 'git repo URL (optionally with #branch) or local path to a templates suite (root must contain templates.json)',
+            longDescription: 'Location of a suite of templates. Can be a git URL with optional #branch suffix or a local filesystem path whose root contains templates.json.',
+            prompt: 'Enter git URL or local path to your templates suite:',
+            error: cli => val => 'Invalid value for template source: \'' + val + '\'.',
+            validate: cli => val => /\S+/.test(val),
+            required: false,
+            type: 'string'
+        },
+        template: {
+            name: 'template',
+            'char': 'm',
+            description: 'template name within the templates suite (e.g. ReactNativeTemplate)',
+            longDescription: 'Name of the template to use from the suite specified by --templatesource. Should match the directory name or the path field in templates.json.',
+            prompt: 'Enter the template name from your template source:',
+            error: cli => val => 'Invalid value for template: \'' + val + '\'.',
+            validate: cli => val => /\S+/.test(val),
+            required: false,
             type: 'string'
         },
         appName: {
@@ -301,7 +325,9 @@ module.exports = {
         createwithtemplate: {
             name: 'createwithtemplate',
             args: cli => [cli.platforms.length > 1 ? 'platform' : null,
+                          'templateSource',
                           'templateRepoUri',
+                          'template',
                           'appName',
                           'packageName',
                           'organization',
@@ -309,7 +335,7 @@ module.exports = {
                           'outputDir',
                           'verbose',
                           cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
-			  'sdkDependencies'			  
+                          'sdkDependencies'              
                          ].filter(x=>x!=null),
             description: cli => 'create ' + cli.purpose + ' from a template',
             longDescription: cli => 'Create ' + cli.purpose + ' from a template.',

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -183,9 +183,8 @@ module.exports = {
             prompt: 'Enter git URL or local path to your templates suite:',
             error: cli => val => 'Invalid value for template source: \'' + val + '\'.',
             validate: cli => val => /\S+/.test(val),
-            // Do not prompt for this optional flag during interactive flows
-            // Tests and most users will not provide it; when provided explicitly, no prompt is needed
-            promptIf: otherArgs => false,
+            // Process only when explicitly provided to avoid prompting during interactive flows
+            promptIf: otherArgs => typeof otherArgs.templatesource !== 'undefined',
             required: false,
             type: 'string'
         },

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -354,10 +354,10 @@ module.exports = {
         },
         listtemplates: {
             name: 'listtemplates',
-            args: [],
+            args: ['templateSource'],
             description: cli => 'list available Mobile SDK templates to create ' + cli.purpose,
             longDescription: cli => 'List available Mobile SDK templates to create ' + cli.purpose + '.',
-            help: 'This command displays the list of available Mobile SDK templates. You can copy repo paths from the output for use with the createwithtemplate command.'
+            help: 'This command displays the list of available Mobile SDK templates. You can copy repo paths from the output for use with the createwithtemplate command. Use --templatesource to specify a custom template repository or leave blank to use the default template repository.'
         },
         checkconfig: {
             name: 'checkconfig',

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -375,7 +375,13 @@ function actuallyCreateApp(forcecli, config) {
             }
         }
         else if (config.templaterepouri) {
-            if (!config.templaterepouri.startsWith("https://")) {
+            if (fs.existsSync(config.templaterepouri)) {
+                // Local path directly to a specific template directory
+                localTemplatesRoot = path.resolve(config.templaterepouri);
+                config.templaterepouri = localTemplatesRoot;
+                // Use the directory itself as the template root
+                config.templatepath = '';
+            } else if (!config.templaterepouri.startsWith("https://")) {
                 // Given a Mobile SDK template name
                 config.templatepath = config.templaterepouri;
                 config.templaterepouri = SDK.templatesRepoUri;

--- a/shared/oclifAdapter.js
+++ b/shared/oclifAdapter.js
@@ -61,19 +61,12 @@ class OclifAdapter extends Command {
         for (let i = 0; i < applicableTemplates.length; i++) {
             const template = applicableTemplates[i];
             logInfo((i + 1) + ') ' + template.description, COLOR.cyan);
-            // If using custom repository, include it in the command
-            let templateUri = template.path;
-            if (templateSourceOrRepoUri) {
-                // Parse the repository URI to separate repo and branch (reuse utils)
-                const parsed = separateRepoUrlPathBranch(templateSourceOrRepoUri);
-                const repoUrl = parsed.repo;
-                const branch = parsed.branch;
-                const includeBranch = templateSourceOrRepoUri.indexOf('#') !== -1 && !!branch;
-                // Format: repository/template-path[#branch]
-                templateUri = repoUrl + '/' + template.path + (includeBranch ? ('#' + branch) : '');
-            }
-            logInfo('sfdx ' + [namespace, cli.topic, SDK.commands.createwithtemplate.name].join(':') + ' --' +
-                SDK.args.templateRepoUri.name + '=' + templateUri, COLOR.magenta);
+            // Recommend using --templatesource and --template
+            const sourceForCommand = templateSourceOrRepoUri || SDK.templatesRepoUri;
+            const cmd = 'sfdx ' + [namespace, cli.topic, SDK.commands.createwithtemplate.name].join(':')
+                + ' --' + SDK.args.templateSource.name + '=' + sourceForCommand
+                + ' --' + SDK.args.template.name + '=' + template.path;
+            logInfo(cmd, COLOR.magenta);
         }
         logInfo('');
     }

--- a/shared/oclifAdapter.js
+++ b/shared/oclifAdapter.js
@@ -46,13 +46,13 @@ class OclifAdapter extends Command {
         return `${description}${os.EOL}${os.EOL}${help}`;
     }
 
-    static listTemplates(cli, templateRepoUri) {
-        const applicableTemplates = templateHelper.getTemplates(cli, templateRepoUri);
+    static listTemplates(cli, templateSourceOrRepoUri) {
+        const applicableTemplates = templateHelper.getTemplates(cli, templateSourceOrRepoUri);
 
         // Show which template repository is being used
-        if (templateRepoUri) {
+        if (templateSourceOrRepoUri) {
             logInfo('\nAvailable templates from custom repository:\n', COLOR.cyan);
-            logInfo('Repository: ' + templateRepoUri, COLOR.cyan);
+            logInfo('Repository: ' + templateSourceOrRepoUri, COLOR.cyan);
         } else {
             logInfo('\nAvailable templates:\n', COLOR.cyan);
         }
@@ -62,9 +62,9 @@ class OclifAdapter extends Command {
             logInfo((i + 1) + ') ' + template.description, COLOR.cyan);
             // If using custom repository, include it in the command
             let templateUri = template.path;
-            if (templateRepoUri) {
+            if (templateSourceOrRepoUri) {
                 // Parse the repository URI to separate repo and branch
-                const repoParts = templateRepoUri.split('#');
+                const repoParts = templateSourceOrRepoUri.split('#');
                 const repoUrl = repoParts[0];
                 const branch = repoParts.length > 1 ? repoParts[1] : '';
                 // Format: repository/template-path#branch

--- a/shared/oclifAdapter.js
+++ b/shared/oclifAdapter.js
@@ -33,6 +33,7 @@ const templateHelper = require('./templateHelper');
 const jsonChecker = require('./jsonChecker');
 const logInfo = require('./utils').logInfo;
 const logError = require('./utils').logError;
+const separateRepoUrlPathBranch = require('./utils').separateRepoUrlPathBranch;
 const os = require('os');
 
 const { SfdxError } = require('@salesforce/core');
@@ -63,12 +64,13 @@ class OclifAdapter extends Command {
             // If using custom repository, include it in the command
             let templateUri = template.path;
             if (templateSourceOrRepoUri) {
-                // Parse the repository URI to separate repo and branch
-                const repoParts = templateSourceOrRepoUri.split('#');
-                const repoUrl = repoParts[0];
-                const branch = repoParts.length > 1 ? repoParts[1] : '';
-                // Format: repository/template-path#branch
-                templateUri = repoUrl + '/' + template.path + (branch ? '#' + branch : '');
+                // Parse the repository URI to separate repo and branch (reuse utils)
+                const parsed = separateRepoUrlPathBranch(templateSourceOrRepoUri);
+                const repoUrl = parsed.repo;
+                const branch = parsed.branch;
+                const includeBranch = templateSourceOrRepoUri.indexOf('#') !== -1 && !!branch;
+                // Format: repository/template-path[#branch]
+                templateUri = repoUrl + '/' + template.path + (includeBranch ? ('#' + branch) : '');
             }
             logInfo('sfdx ' + [namespace, cli.topic, SDK.commands.createwithtemplate.name].join(':') + ' --' +
                 SDK.args.templateRepoUri.name + '=' + templateUri, COLOR.magenta);

--- a/shared/templateHelper.js
+++ b/shared/templateHelper.js
@@ -36,7 +36,7 @@ var path = require('path'),
 function prepareTemplate(config, templateDir) {
     var template = require(path.join(templateDir, 'template.js'));
     return utils.runFunctionThrowError(
-        function() {
+        function () {
             return template.prepare(config, utils.replaceInFiles, utils.moveFile, utils.removeFile);
         },
         templateDir);
@@ -45,14 +45,17 @@ function prepareTemplate(config, templateDir) {
 //
 // Get templates for the given cli
 //
-function getTemplates(cli) {
+function getTemplates(cli, templateRepoUri) {
     try {
 
         // Creating tmp dir for template clone
         var tmpDir = utils.mkTmpDir();
 
+        // Use provided templateRepoUri or fall back to default
+        var repoUri = templateRepoUri || SDK.templatesRepoUri;
+
         // Cloning template repo
-        var repoDir = utils.cloneRepo(tmpDir, SDK.templatesRepoUri);
+        var repoDir = utils.cloneRepo(tmpDir, repoUri);
 
         // Getting list of templates
         var templates = require(path.join(repoDir, 'templates.json'));


### PR DESCRIPTION
Currently if you call

`forceios listTemplates` 

It will only return you the templates that live at the 1st party template repository https://github.com/forcedotcom/SalesforceMobileSDK-Templates

If I maintain my own template repository, I wish this command to list all available templates at that repository, 

i.e.

`forceios listTemplates --templaterepouri=https://github.com/jhorst11/SalesforceMobileSDK-Templates#spike-templates`

Should should me all the templates located at my fork/branch.

Furthermore the changes introduce a new parameter to `listTemplates` and `createWithTemplate` called `templatesource` and a corresponding `template` which similarly allow you to point the cli to a suite of templates hosted either locally or remotely. Examples:

`forceios createwithtemplate --templatesource=/Users/justin.horst/Repos/scratch/SalesforceMobileSDK-Templates --template=MobileSyncExplorerSwift`

`forceios listTemplates --templatesource=/Users/justin.horst/Repos/scratch/SalesforceMobileSDK-Templates`

`forceios createwithtemplate --templatesource=https://github.com/jhorst11/SalesforceMobileSDK-Templates#spike-templates --template=MobileSyncExplorerSwift`