### PR TITLE
New optional args for the CLIs: consumer key, callback URL and login server

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -41,6 +41,7 @@ forcedroid create
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 
@@ -55,6 +56,7 @@ forcedroid createwithtemplate
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 

--- a/android/README.md
+++ b/android/README.md
@@ -39,6 +39,8 @@ forcedroid create
     --packagename=app package identifier (e.g. com.mycompany.myapp)
     --organization=organization name (your company's/organization's name)
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 
@@ -51,6 +53,8 @@ forcedroid createwithtemplate
     --packagename=app package identifier (e.g. com.mycompany.myapp)
     --organization=organization name (your company's/organization's name)
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 

--- a/hybrid/README.md
+++ b/hybrid/README.md
@@ -41,6 +41,8 @@ forcehybrid create
     --organization=organization name (your company's/organization's name)
     [--startpage=app start page (the start page of your remote app; required for hybrid_remote apps only)]
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 
@@ -55,6 +57,8 @@ forcehybrid createwithtemplate
     --organization=organization name (your company's/organization's name)
     [--startpage=app start page (the start page of your remote app; required for hybrid_remote apps only)]
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 

--- a/hybrid/README.md
+++ b/hybrid/README.md
@@ -43,6 +43,7 @@ forcehybrid create
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 
@@ -59,6 +60,7 @@ forcehybrid createwithtemplate
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -39,6 +39,8 @@ forceios create
     --packagename=app package identifier (e.g. com.mycompany.myapp)
     --organization=organization name (your company's/organization's name)
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 
@@ -51,6 +53,8 @@ forceios createwithtemplate
     --packagename=app package identifier (e.g. com.mycompany.myapp)
     --organization=organization name (your company's/organization's name)
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 

--- a/ios/README.md
+++ b/ios/README.md
@@ -41,6 +41,7 @@ forceios create
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 
@@ -55,6 +56,7 @@ forceios createwithtemplate
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 

--- a/react/README.md
+++ b/react/README.md
@@ -40,6 +40,8 @@ forcereact create
     --packagename=app package identifier (e.g. com.mycompany.myapp)
     --organization=organization name (your company's/organization's name)
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 
@@ -53,6 +55,8 @@ forcereact createwithtemplate
     --packagename=app package identifier (e.g. com.mycompany.myapp)
     --organization=organization name (your company's/organization's name)
     [--outputdir=output directory (leave empty for current directory)]
+    [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
+    [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
 
  OR 
 

--- a/react/README.md
+++ b/react/README.md
@@ -42,6 +42,7 @@ forcereact create
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 
@@ -57,6 +58,7 @@ forcereact createwithtemplate
     [--outputdir=output directory (leave empty for current directory)]
     [--consumerkey=OAuth consumer key for the Salesforce External Client App or Connected App]
     [--callbackurl=OAuth callback URL for the Salesforce External Client App or Connected App]
+    [--loginserver=Login server URL for the Salesforce org]
 
  OR 
 

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -66,7 +66,7 @@ create an iOS native mobile application
 
 USAGE
   $ sf mobilesdk ios create -n <value> -k <value> -o <value> [-t <value>] [-d
-    <value>] [-c <value>] [-u <value>]
+    <value>] [-c <value>] [-u <value>] [-l <value>]
 
 FLAGS
   -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
@@ -75,6 +75,7 @@ FLAGS
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
                               com.mycompany.myapp)
+  -l, --loginserver=<value>   Login server URL for the Salesforce org
   -n, --appname=<value>       (required) application name
   -o, --organization=<value>  (required) organization name (your
                               company's/organization's name)
@@ -126,7 +127,7 @@ create an iOS native mobile application from a template
 
 USAGE
   $ sf mobilesdk ios createwithtemplate -n <value> -k <value> -o <value> [-S <value>] [-r
-    <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>]
+    <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>] [-l <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
@@ -138,6 +139,7 @@ FLAGS
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
                                  com.mycompany.myapp)
+  -l, --loginserver=<value>      Login server URL for the Salesforce org
   -m, --template=<value>         template name within the templates suite (e.g.
                                  ReactNativeTemplate)
   -n, --appname=<value>          (required) application name
@@ -211,7 +213,7 @@ create an Android native mobile application
 
 USAGE
   $ sf mobilesdk android create -n <value> -k <value> -o <value> [-t <value>] [-d
-    <value>] [-c <value>] [-u <value>]
+    <value>] [-c <value>] [-u <value>] [-l <value>]
 
 FLAGS
   -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
@@ -220,6 +222,7 @@ FLAGS
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
                               com.mycompany.myapp)
+  -l, --loginserver=<value>   Login server URL for the Salesforce org
   -n, --appname=<value>       (required) application name
   -o, --organization=<value>  (required) organization name (your
                               company's/organization's name)
@@ -272,7 +275,7 @@ create an Android native mobile application from a template
 
 USAGE
   $ sf mobilesdk android createwithtemplate -n <value> -k <value> -o <value> [-S <value>] [-r
-    <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>]
+    <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>] [-l <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
@@ -284,6 +287,7 @@ FLAGS
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
                                  com.mycompany.myapp)
+  -l, --loginserver=<value>      Login server URL for the Salesforce org
   -m, --template=<value>         template name within the templates suite (e.g.
                                  ReactNativeTemplate)
   -n, --appname=<value>          (required) application name
@@ -355,7 +359,7 @@ create a hybrid mobile application
 
 USAGE
   $ sf mobilesdk hybrid create -p <value> -n <value> -k <value> -o <value> [-t
-    <value>] [-s <value>] [-d <value>] [-c <value>] [-u <value>]
+    <value>] [-s <value>] [-d <value>] [-c <value>] [-u <value>] [-l <value>]
 
 FLAGS
   -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
@@ -364,6 +368,7 @@ FLAGS
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
                               com.mycompany.myapp)
+  -l, --loginserver=<value>   Login server URL for the Salesforce org
   -n, --appname=<value>       (required) application name
   -o, --organization=<value>  (required) organization name (your
                               company's/organization's name)
@@ -420,7 +425,7 @@ create a hybrid mobile application from a template
 USAGE
   $ sf mobilesdk hybrid createwithtemplate -p <value> -n <value> -k <value> -o <value> [-S
     <value>] [-r <value>] [-m <value>] [-s <value>] [-d <value>] [-c <value>]
-    [-u <value>]
+    [-u <value>] [-l <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
@@ -432,6 +437,7 @@ FLAGS
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
                                  com.mycompany.myapp)
+  -l, --loginserver=<value>      Login server URL for the Salesforce org
   -m, --template=<value>         template name within the templates suite (e.g.
                                  ReactNativeTemplate)
   -n, --appname=<value>          (required) application name
@@ -510,7 +516,7 @@ create a React Native mobile application
 
 USAGE
   $ sf mobilesdk reactnative create -p <value> -n <value> -k <value> -o <value> [-t
-    <value>] [-d <value>] [-c <value>] [-u <value>]
+    <value>] [-d <value>] [-c <value>] [-u <value>] [-l <value>]
 
 FLAGS
   -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
@@ -519,6 +525,7 @@ FLAGS
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
                               com.mycompany.myapp)
+  -l, --loginserver=<value>   Login server URL for the Salesforce org
   -n, --appname=<value>       (required) application name
   -o, --organization=<value>  (required) organization name (your
                               company's/organization's name)
@@ -575,6 +582,7 @@ create a React Native mobile application from a template
 USAGE
   $ sf mobilesdk reactnative createwithtemplate -p <value> -n <value> -k <value> -o <value> [-S
     <value>] [-r <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>]
+    [-l <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
@@ -586,6 +594,7 @@ FLAGS
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
                                  com.mycompany.myapp)
+  -l, --loginserver=<value>      Login server URL for the Salesforce org
   -m, --template=<value>         template name within the templates suite (e.g.
                                  ReactNativeTemplate)
   -n, --appname=<value>          (required) application name

--- a/sfdx/README.md
+++ b/sfdx/README.md
@@ -66,9 +66,11 @@ create an iOS native mobile application
 
 USAGE
   $ sf mobilesdk ios create -n <value> -k <value> -o <value> [-t <value>] [-d
-    <value>]
+    <value>] [-c <value>] [-u <value>]
 
 FLAGS
+  -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
+                              Client App or Connected App
   -d, --outputdir=<value>     output directory (leave empty for current
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
@@ -78,6 +80,8 @@ FLAGS
                               company's/organization's name)
   -t, --apptype=<value>       application type (native_swift or native, leave
                               empty for native_swift)
+  -u, --callbackurl=<value>   OAuth callback URL for the Salesforce External
+                              Client App or Connected App
 
 DESCRIPTION
   create an iOS native mobile application
@@ -122,12 +126,14 @@ create an iOS native mobile application from a template
 
 USAGE
   $ sf mobilesdk ios createwithtemplate -n <value> -k <value> -o <value> [-S <value>] [-r
-    <value>] [-m <value>] [-d <value>]
+    <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
                                  path to a templates suite (root must contain
                                  templates.json)
+  -c, --consumerkey=<value>      OAuth consumer key for the Salesforce External
+                                 Client App or Connected App
   -d, --outputdir=<value>        output directory (leave empty for current
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
@@ -138,6 +144,8 @@ FLAGS
   -o, --organization=<value>     (required) organization name (your
                                  company's/organization's name)
   -r, --templaterepouri=<value>  template repo URI or Mobile SDK template name
+  -u, --callbackurl=<value>      OAuth callback URL for the Salesforce External
+                                 Client App or Connected App
 
 DESCRIPTION
   create an iOS native mobile application from a template
@@ -203,9 +211,11 @@ create an Android native mobile application
 
 USAGE
   $ sf mobilesdk android create -n <value> -k <value> -o <value> [-t <value>] [-d
-    <value>]
+    <value>] [-c <value>] [-u <value>]
 
 FLAGS
+  -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
+                              Client App or Connected App
   -d, --outputdir=<value>     output directory (leave empty for current
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
@@ -215,6 +225,8 @@ FLAGS
                               company's/organization's name)
   -t, --apptype=<value>       application type (native_kotlin or native, leave
                               empty for native_kotlin)
+  -u, --callbackurl=<value>   OAuth callback URL for the Salesforce External
+                              Client App or Connected App
 
 DESCRIPTION
   create an Android native mobile application
@@ -260,12 +272,14 @@ create an Android native mobile application from a template
 
 USAGE
   $ sf mobilesdk android createwithtemplate -n <value> -k <value> -o <value> [-S <value>] [-r
-    <value>] [-m <value>] [-d <value>]
+    <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
                                  path to a templates suite (root must contain
                                  templates.json)
+  -c, --consumerkey=<value>      OAuth consumer key for the Salesforce External
+                                 Client App or Connected App
   -d, --outputdir=<value>        output directory (leave empty for current
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
@@ -276,6 +290,8 @@ FLAGS
   -o, --organization=<value>     (required) organization name (your
                                  company's/organization's name)
   -r, --templaterepouri=<value>  template repo URI or Mobile SDK template name
+  -u, --callbackurl=<value>      OAuth callback URL for the Salesforce External
+                                 Client App or Connected App
 
 DESCRIPTION
   create an Android native mobile application from a template
@@ -339,9 +355,11 @@ create a hybrid mobile application
 
 USAGE
   $ sf mobilesdk hybrid create -p <value> -n <value> -k <value> -o <value> [-t
-    <value>] [-s <value>] [-d <value>]
+    <value>] [-s <value>] [-d <value>] [-c <value>] [-u <value>]
 
 FLAGS
+  -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
+                              Client App or Connected App
   -d, --outputdir=<value>     output directory (leave empty for current
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
@@ -355,6 +373,8 @@ FLAGS
                               required for hybrid_remote apps only)
   -t, --apptype=<value>       application type (hybrid_local or hybrid_remote,
                               leave empty for hybrid_local)
+  -u, --callbackurl=<value>   OAuth callback URL for the Salesforce External
+                              Client App or Connected App
 
 DESCRIPTION
   create a hybrid mobile application
@@ -399,12 +419,15 @@ create a hybrid mobile application from a template
 
 USAGE
   $ sf mobilesdk hybrid createwithtemplate -p <value> -n <value> -k <value> -o <value> [-S
-    <value>] [-r <value>] [-m <value>] [-s <value>] [-d <value>]
+    <value>] [-r <value>] [-m <value>] [-s <value>] [-d <value>] [-c <value>]
+    [-u <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
                                  path to a templates suite (root must contain
                                  templates.json)
+  -c, --consumerkey=<value>      OAuth consumer key for the Salesforce External
+                                 Client App or Connected App
   -d, --outputdir=<value>        output directory (leave empty for current
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
@@ -419,6 +442,8 @@ FLAGS
   -r, --templaterepouri=<value>  template repo URI or Mobile SDK template name
   -s, --startpage=<value>        app start page (the start page of your remote
                                  app; required for hybrid_remote apps only)
+  -u, --callbackurl=<value>      OAuth callback URL for the Salesforce External
+                                 Client App or Connected App
 
 DESCRIPTION
   create a hybrid mobile application from a template
@@ -485,9 +510,11 @@ create a React Native mobile application
 
 USAGE
   $ sf mobilesdk reactnative create -p <value> -n <value> -k <value> -o <value> [-t
-    <value>] [-d <value>]
+    <value>] [-d <value>] [-c <value>] [-u <value>]
 
 FLAGS
+  -c, --consumerkey=<value>   OAuth consumer key for the Salesforce External
+                              Client App or Connected App
   -d, --outputdir=<value>     output directory (leave empty for current
                               directory)
   -k, --packagename=<value>   (required) app package identifier (e.g.
@@ -500,6 +527,8 @@ FLAGS
   -t, --apptype=<value>       application type (react_native_typescript or
                               react_native, leave empty for
                               react_native_typescript)
+  -u, --callbackurl=<value>   OAuth callback URL for the Salesforce External
+                              Client App or Connected App
 
 DESCRIPTION
   create a React Native mobile application
@@ -545,12 +574,14 @@ create a React Native mobile application from a template
 
 USAGE
   $ sf mobilesdk reactnative createwithtemplate -p <value> -n <value> -k <value> -o <value> [-S
-    <value>] [-r <value>] [-m <value>] [-d <value>]
+    <value>] [-r <value>] [-m <value>] [-d <value>] [-c <value>] [-u <value>]
 
 FLAGS
   -S, --templatesource=<value>   git repo URL (optionally with #branch) or local
                                  path to a templates suite (root must contain
                                  templates.json)
+  -c, --consumerkey=<value>      OAuth consumer key for the Salesforce External
+                                 Client App or Connected App
   -d, --outputdir=<value>        output directory (leave empty for current
                                  directory)
   -k, --packagename=<value>      (required) app package identifier (e.g.
@@ -563,6 +594,8 @@ FLAGS
   -p, --platform=<value>         (required) comma-separated list of platforms
                                  (ios, android)
   -r, --templaterepouri=<value>  template repo URI or Mobile SDK template name
+  -u, --callbackurl=<value>      OAuth callback URL for the Salesforce External
+                                 Client App or Connected App
 
 DESCRIPTION
   create a React Native mobile application from a template

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -351,6 +351,17 @@ module.exports = {
             validate: cli => val => val === undefined || val === '' || /\S+/.test(val),
             required: false,
             type: 'string'
+        },
+        loginServer: {
+            name: 'loginserver',
+            'char': 'l',
+            description: 'Login server URL for the Salesforce org',
+            longDescription: 'The login server URL for your Salesforce org (e.g. https://login.salesforce.com, https://test.salesforce.com, or custom domain). When provided, this will be automatically configured in the generated app.',
+            prompt: 'Enter your login server URL (leave empty for https://login.salesforce.com):',
+            error: cli => val => 'Invalid value for login server: \'' + val + '\'.',
+            validate: cli => val => val === undefined || val === '' || /\S+/.test(val),
+            required: false,
+            type: 'string'
         }
     },
 
@@ -366,6 +377,7 @@ module.exports = {
                           'outputDir',
                           'consumerKey',
                           'callbackURL',
+                          'loginServer',
                           'verbose',
                           cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
 			  'sdkDependencies'
@@ -387,6 +399,7 @@ module.exports = {
                           'outputDir',
                           'consumerKey',
                           'callbackURL',
+                          'loginServer',
                           'verbose',
                           cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
                           'sdkDependencies'              

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -296,7 +296,7 @@ module.exports = {
             type: 'string',
             hidden: true
         },
-	sdkDependencies: {
+	    sdkDependencies: {
             name: 'sdkdependencies',
             description: 'override sdk dependencies',
             'char': 'd',
@@ -329,6 +329,28 @@ module.exports = {
             required: false,
             type: 'boolean',
             hidden: false
+        },
+        consumerKey: {
+            name: 'consumerkey',
+            'char': 'c',
+            description: 'OAuth consumer key for the Salesforce External Client App or Connected App',
+            longDescription: 'The OAuth consumer key (client ID) for your Salesforce External Client App or Connected App. When provided, this will be automatically configured in the generated app.',
+            prompt: 'Enter your OAuth consumer key (leave empty to manually configure this value in the project\'s bootconfig file):',
+            error: cli => val => 'Invalid value for consumer key: \'' + val + '\'.',
+            validate: cli => val => val === undefined || val === '' || /\S+/.test(val),
+            required: false,
+            type: 'string'
+        },
+        callbackURL: {
+            name: 'callbackurl',
+            'char': 'u',
+            description: 'OAuth callback URL for the Salesforce External Client App or Connected App',
+            longDescription: 'The OAuth callback URL (redirect URI) for your Salesforce External Client App or Connected App. When provided, this will be automatically configured in the generated app.',
+            prompt: 'Enter your OAuth callback URL (leave empty to manually configure this value in the project\'s bootconfig file):',
+            error: cli => val => 'Invalid value for callback URL: \'' + val + '\'.',
+            validate: cli => val => val === undefined || val === '' || /\S+/.test(val),
+            required: false,
+            type: 'string'
         }
     },
 
@@ -342,6 +364,8 @@ module.exports = {
                           'organization',
                           cli.appTypes.indexOf('hybrid_remote') >=0 ? 'startPage' : null,
                           'outputDir',
+                          'consumerKey',
+                          'callbackURL',
                           'verbose',
                           cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
 			  'sdkDependencies'
@@ -361,6 +385,8 @@ module.exports = {
                           'organization',
                           cli.appTypes.indexOf('hybrid_remote') >=0 ? 'startPage' : null,
                           'outputDir',
+                          'consumerKey',
+                          'callbackURL',
                           'verbose',
                           cli.name === 'forcehybrid' ? 'pluginRepoUri' : null,
                           'sdkDependencies'              

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -147,44 +147,44 @@ function createAndroidAPI35Theme(projectDir) {
 function printDetails(config) {
     // Printing out details
     var details = ['Creating ' + config.platform.replace(',', ' and ') + ' ' + config.apptype + ' application using Salesforce Mobile SDK',
-                        '  with app name:        ' + config.appname,
-                        '       package name:    ' + config.packagename,
-                        '       organization:    ' + config.organization,
+                        '  with app name:         ' + config.appname,
+                        '       package name:     ' + config.packagename,
+                        '       organization:     ' + config.organization,
                         '',
-                        '  in:                   ' + config.projectPath,
+                        '  in:                    ' + config.projectPath,
                         '',
-                        '  from template repo:   ' + config.templaterepouri
+                        '  from template repo:    ' + config.templaterepouri
                   ];
 
     if (config.templatepath) {
-        details = details.concat(['       template path:   ' + config.templatepath]);
+        details = details.concat(['       template path:    ' + config.templatepath]);
     }
             
 
     if (config.sdkdependencies) {
-        details = details.concat(['       sdk dependencies:   ' + config.sdkdependencies]);
+        details = details.concat(['       sdk dependencies: ' + config.sdkdependencies]);
     }
 
     // OAuth configuration details
     if (config.consumerkey && config.consumerkey !== '__INSERT_CONSUMER_KEY_HERE__' && config.consumerkey.trim() !== '') {
-        details = details.concat(['       consumer key:       ' + config.consumerkey]);
+        details = details.concat(['       consumer key:     ' + config.consumerkey]);
     }
 
     if (config.callbackurl && config.callbackurl !== '__INSERT_CALLBACK_URL_HERE__' && config.callbackurl.trim() !== '') {
-        details = details.concat(['       callback URL:       ' + config.callbackurl]);
+        details = details.concat(['       callback URL:     ' + config.callbackurl]);
     }
 
     if (config.loginserver && config.loginserver.trim() !== '') {
-        details = details.concat(['       login server:       ' + config.loginserver]);
+        details = details.concat(['       login server:     ' + config.loginserver]);
     }
             
     // Hybrid extra details
     if (config.apptype.indexOf('hybrid') >= 0) {
         if (config.apptype === 'hybrid_remote') {
-            details = details.concat(['       start page:      ' + config.startpage]);
+            details = details.concat(['       start page:       ' + config.startpage]);
         }
 
-        details = details.concat(['       plugin repo:     ' + config.cordovaPluginRepoUri]);
+        details = details.concat(['       plugin repo:      ' + config.cordovaPluginRepoUri]);
     }
             
     utils.logParagraph(details);

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -164,6 +164,19 @@ function printDetails(config) {
     if (config.sdkdependencies) {
         details = details.concat(['       sdk dependencies:   ' + config.sdkdependencies]);
     }
+
+    // OAuth configuration details
+    if (config.consumerkey && config.consumerkey !== '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__' && config.consumerkey.trim() !== '') {
+        details = details.concat(['       consumer key:       ' + config.consumerkey]);
+    }
+
+    if (config.callbackurl && config.callbackurl !== '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__' && config.callbackurl.trim() !== '') {
+        details = details.concat(['       callback URL:       ' + config.callbackurl]);
+    }
+
+    if (config.loginserver && config.loginserver.trim() !== '') {
+        details = details.concat(['       login server:       ' + config.loginserver]);
+    }
             
     // Hybrid extra details
     if (config.apptype.indexOf('hybrid') >= 0) {
@@ -185,7 +198,8 @@ function hasValidOAuthConfig(config) {
            config.consumerkey !== '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__' &&
            config.callbackurl !== '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__' &&
            config.consumerkey.trim() !== '' && 
-           config.callbackurl.trim() !== '';
+           config.callbackurl.trim() !== '' &&
+           (!config.loginserver || config.loginserver.trim() !== '');
 }
 
 //
@@ -199,14 +213,15 @@ function printNextSteps(ide, projectPath, result, hasValidOAuth) {
                      '',
                      'Your application project is ready in ' + projectPath + '.',
                      'To use your new application in ' + ide + ', do the following:', 
-                     '   - open ' + workspacePath + ' in ' + ide, 
-                     '   - build and run'];
+                     '   - open ' + workspacePath + ' in ' + ide];
 
     // Only show OAuth configuration instructions if valid OAuth config was not provided
     if (!hasValidOAuth) {
-        nextSteps.push('Before you ship, make sure to plug your OAuth Client ID and Callback URI,');
-        nextSteps.push('and OAuth Scopes into ' + bootconfigFile);
+        nextSteps.push('   - make sure to plug your OAuth Client ID and Callback URI');
+        nextSteps.push('     into ' + bootconfigFile);
     }
+
+    nextSteps.push('   - build and run');
 
     // Printing out next steps
     utils.logParagraph(nextSteps);
@@ -228,17 +243,13 @@ function printNextStepsForNativeLogin(ide, projectPath, result, hasValidOAuth) {
 
     // Only show OAuth configuration instructions if valid OAuth config was not provided
     if (!hasValidOAuth) {
-        nextSteps.push('   - Update the OAuth Client ID, Callback URI, and Community URL in ' + entryFile + ' class.');
+        nextSteps.push('   - Update the OAuth Client ID, Callback URI, and Community URL in ' + entryFile + ' class.');        
+        nextSteps.push('   - Make sure to plug your OAuth Client ID and Callback URI into');
+        nextSteps.push('     into ' + bootconfigFile);
+        nextSteps.push('     since it is still be used for authentication if we fallback on the webview.');
     }
 
     nextSteps.push('   - build and run');
-
-    // Only show bootconfig OAuth instructions if valid OAuth config was not provided
-    if (!hasValidOAuth) {
-        nextSteps.push('Before you ship, make sure to plug your OAuth Client ID and Callback URI,');
-        nextSteps.push('and OAuth Scopes into ' + bootconfigFile + ', since it is still used for');
-        nextSteps.push('authentication if we fallback on the webview.');
-    }
 
     // Printing out next steps
     utils.logParagraph(nextSteps);

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -178,44 +178,70 @@ function printDetails(config) {
 }
 
 //
+// Check if valid OAuth configuration is provided
+//
+function hasValidOAuthConfig(config) {
+    return config.consumerkey && config.callbackurl &&
+           config.consumerkey !== '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__' &&
+           config.callbackurl !== '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__' &&
+           config.consumerkey.trim() !== '' && 
+           config.callbackurl.trim() !== '';
+}
+
+//
 // Print next steps
 //
-function printNextSteps(ide, projectPath, result) {
+function printNextSteps(ide, projectPath, result, hasValidOAuth) {
     var workspacePath = path.join(projectPath, result.workspacePath);
     var bootconfigFile =  path.join(projectPath, result.bootconfigFile);
 
+    var nextSteps = ['Next steps' + (result.platform ? ' for ' + result.platform : '') + ':',
+                     '',
+                     'Your application project is ready in ' + projectPath + '.',
+                     'To use your new application in ' + ide + ', do the following:', 
+                     '   - open ' + workspacePath + ' in ' + ide, 
+                     '   - build and run'];
+
+    // Only show OAuth configuration instructions if valid OAuth config was not provided
+    if (!hasValidOAuth) {
+        nextSteps.push('Before you ship, make sure to plug your OAuth Client ID and Callback URI,');
+        nextSteps.push('and OAuth Scopes into ' + bootconfigFile);
+    }
+
     // Printing out next steps
-    utils.logParagraph(['Next steps' + (result.platform ? ' for ' + result.platform : '') + ':',
-                        '',
-                        'Your application project is ready in ' + projectPath + '.',
-                        'To use your new application in ' + ide + ', do the following:', 
-                        '   - open ' + workspacePath + ' in ' + ide, 
-                        '   - build and run', 
-                        'Before you ship, make sure to plug your OAuth Client ID and Callback URI,',
-                        'and OAuth Scopes into ' + bootconfigFile,
-                       ]);
+    utils.logParagraph(nextSteps);
 };    
 
 //
 // Print next steps for Native Login
 // 
-function printNextStepsForNativeLogin(ide, projectPath, result) {
+function printNextStepsForNativeLogin(ide, projectPath, result, hasValidOAuth) {
     var workspacePath = path.join(projectPath, result.workspacePath);
     var bootconfigFile =  path.join(projectPath, result.bootconfigFile);
     var entryFile = (ide === 'XCode') ? 'SceneDelegate' : 'MainApplication';  
 
+    var nextSteps = ['Next steps' + (result.platform ? ' for ' + result.platform : '') + ':',
+                     '',
+                     'Your application project is ready in ' + projectPath + '.',
+                     'To use your new application in ' + ide + ', do the following:', 
+                     '   - open ' + workspacePath + ' in ' + ide];
+
+    // Only show OAuth configuration instructions if valid OAuth config was not provided
+    if (!hasValidOAuth) {
+        nextSteps.push('   - Update the OAuth Client ID, Callback URI, and Community URL in ' + entryFile + ' class.');
+    }
+
+    nextSteps.push('   - build and run');
+
+    // Only show bootconfig OAuth instructions if valid OAuth config was not provided
+    if (!hasValidOAuth) {
+        nextSteps.push('Before you ship, make sure to plug your OAuth Client ID and Callback URI,');
+        nextSteps.push('and OAuth Scopes into ' + bootconfigFile + ', since it is still used for');
+        nextSteps.push('authentication if we fallback on the webview.');
+    }
+
     // Printing out next steps
-    utils.logParagraph(['Next steps' + (result.platform ? ' for ' + result.platform : '') + ':',
-                        '',
-                        'Your application project is ready in ' + projectPath + '.',
-                        'To use your new application in ' + ide + ', do the following:', 
-                        '   - open ' + workspacePath + ' in ' + ide, 
-                        '   - Update the OAuth Client ID, Callback URI, and Community URL in ' + entryFile + ' class.',
-                        '   - build and run', 
-                        'Before you ship, make sure to plug your OAuth Client ID and Callback URI,',
-                        'and OAuth Scopes into ' + bootconfigFile + ', since it is still used for',
-                        'authentication if we fallback on the webview.'
-                       ]);
+    utils.logParagraph(nextSteps);
 }
 
 //
@@ -435,13 +461,14 @@ function actuallyCreateApp(forcecli, config) {
         
         // Printing next steps
         if (!(results instanceof Array)) { results = [results] };
+        var hasValidOAuth = hasValidOAuthConfig(config);
         for (var result of results) {
             var ide = SDK.ides[result.platform || config.platform.split(',')[0]];
 
             if (config.templatepath != undefined && config.templatepath.includes('NativeLogin')) {
-                printNextStepsForNativeLogin(ide, config.projectPath, result);
+                printNextStepsForNativeLogin(ide, config.projectPath, result, hasValidOAuth);
             } else {
-                printNextSteps(ide, config.projectPath, result);
+                printNextSteps(ide, config.projectPath, result, hasValidOAuth);
             }
         }
         printNextStepsForServerProjectIfNeeded(config.projectPath);

--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -166,11 +166,11 @@ function printDetails(config) {
     }
 
     // OAuth configuration details
-    if (config.consumerkey && config.consumerkey !== '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__' && config.consumerkey.trim() !== '') {
+    if (config.consumerkey && config.consumerkey !== '__INSERT_CONSUMER_KEY_HERE__' && config.consumerkey.trim() !== '') {
         details = details.concat(['       consumer key:       ' + config.consumerkey]);
     }
 
-    if (config.callbackurl && config.callbackurl !== '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__' && config.callbackurl.trim() !== '') {
+    if (config.callbackurl && config.callbackurl !== '__INSERT_CALLBACK_URL_HERE__' && config.callbackurl.trim() !== '') {
         details = details.concat(['       callback URL:       ' + config.callbackurl]);
     }
 
@@ -195,8 +195,8 @@ function printDetails(config) {
 //
 function hasValidOAuthConfig(config) {
     return config.consumerkey && config.callbackurl &&
-           config.consumerkey !== '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__' &&
-           config.callbackurl !== '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__' &&
+           config.consumerkey !== '__INSERT_CONSUMER_KEY_HERE__' &&
+           config.callbackurl !== '__INSERT_CALLBACK_URL_HERE__' &&
            config.consumerkey.trim() !== '' && 
            config.callbackurl.trim() !== '' &&
            (!config.loginserver || config.loginserver.trim() !== '');

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -59,6 +59,7 @@ function main(args) {
     var sdkDependencies = parsedArgs.sdkdependencies;
     var consumerKey = parsedArgs.consumerkey || '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__';
     var callbackURL = parsedArgs.callbackurl || '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__';
+    var loginServer = parsedArgs.loginserver || 'https://login.salesforce.com';
 
     var testingWithOS = chosenOperatingSystems.length > 0;
     var testingWithClis = chosenClis.length > 0;
@@ -161,7 +162,7 @@ function main(args) {
                 for (var k=0; k<template.platforms.length; k++) {
                     var os = template.platforms[k];
                     if (chosenOperatingSystems.length == 0 || chosenOperatingSystems.indexOf(os) >= 0) {
-                        createCompileApp(tmpDir, os, template.appType, template.path, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL);
+                        createCompileApp(tmpDir, os, template.appType, template.path, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL, loginServer);
                     }
                 }
             }
@@ -173,14 +174,14 @@ function main(args) {
             if (testingWithAppType) {
                 for (var j=0; j<chosenAppTypes.length; j++) {
                     var appType = chosenAppTypes[j];
-                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL);
+                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL, loginServer);
                 }
             }
 
             if (testingWithTemplate) {
                 // NB: chosenAppTypes[0] is appType from template
                 var appType = chosenAppTypes.length > 0 ? chosenAppTypes[0] : [templateHelper.getAppTypeFromTemplate(templateRepoUri)];
-                createCompileApp(tmpDir, os, appType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL);
+                createCompileApp(tmpDir, os, appType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL, loginServer);
             }
         }
     }
@@ -205,6 +206,7 @@ function shortUsage(exitCode) {
     utils.logInfo('    [--sdkdependencies=SDK_DEPDENDENCIES_OVERRIDE]', COLOR.magenta);
     utils.logInfo('    [--consumerkey=OAUTH_CONSUMER_KEY]', COLOR.magenta);
     utils.logInfo('    [--callbackurl=OAUTH_CALLBACK_URL]', COLOR.magenta);
+    utils.logInfo('    [--loginserver=LOGIN_SERVER_URL]', COLOR.magenta);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);
@@ -214,6 +216,7 @@ function shortUsage(exitCode) {
     utils.logInfo('  - sdkdependencies is like {\"SalesforceMobileSDK-iOS\":\"https://github.com/somefork/SalesforceMobileSDK-iOS#somebranch\"}', COLOR.cyan);
     utils.logInfo('  - consumerkey is the OAuth consumer key for the Salesforce External Client App or Connected App', COLOR.cyan);
     utils.logInfo('  - callbackurl is the OAuth callback URL for the Salesforce External Client App or Connected App', COLOR.cyan);
+    utils.logInfo('  - loginserver is the login server URL for the Salesforce org', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
 
     if (typeof(exitCode) !== 'undefined') {
@@ -305,7 +308,7 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
 //
 // Create and compile app
 //
-function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL) {
+function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL, loginServer) {
     var execArgs = '';
     var isNative = actualAppType == APP_TYPE.native || actualAppType == APP_TYPE.native_swift || actualAppType == APP_TYPE.native_kotlin; 
     var isReactNative = actualAppType == APP_TYPE.react_native || actualAppType == APP_TYPE.react_native_typescript;
@@ -363,7 +366,8 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
         + ' --organization=Salesforce'
         + ' --outputdir=' + outputDir
         + ' --consumerkey=' + consumerKey
-        + ' --callbackurl=' + callbackURL       
+        + ' --callbackurl=' + callbackURL
+        + ' --loginserver=' + loginServer      
         + ' --verbose'
         + (isHybridRemote ? ' --startpage=' + defaultStartPage : '')
         + (isHybrid && pluginRepoUri ? ' --pluginrepouri=' + pluginRepoUri : '');

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -57,8 +57,8 @@ function main(args) {
     var chosenAppTypes = cleanSplit(parsedArgs.apptype, ',');
     var chosenClis = cleanSplit(parsedArgs.cli, ',');
     var sdkDependencies = parsedArgs.sdkdependencies;
-    var consumerKey = parsedArgs.consumerkey || '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__';
-    var callbackURL = parsedArgs.callbackurl || '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__';
+    var consumerKey = parsedArgs.consumerkey || '__INSERT_CONSUMER_KEY_HERE__';
+    var callbackURL = parsedArgs.callbackurl || '__INSERT_CALLBACK_URL_HERE__';
     var loginServer = parsedArgs.loginserver || 'https://login.salesforce.com';
 
     var testingWithOS = chosenOperatingSystems.length > 0;

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -57,6 +57,8 @@ function main(args) {
     var chosenAppTypes = cleanSplit(parsedArgs.apptype, ',');
     var chosenClis = cleanSplit(parsedArgs.cli, ',');
     var sdkDependencies = parsedArgs.sdkdependencies;
+    var consumerKey = parsedArgs.consumerkey || '__INSERT_REMOTE_ACCESS_CLIENT_KEY_HERE__';
+    var callbackURL = parsedArgs.callbackurl || '__INSERT_REMOTE_ACCESS_CALLBACK_URL_HERE__';
 
     var testingWithOS = chosenOperatingSystems.length > 0;
     var testingWithClis = chosenClis.length > 0;
@@ -159,7 +161,7 @@ function main(args) {
                 for (var k=0; k<template.platforms.length; k++) {
                     var os = template.platforms[k];
                     if (chosenOperatingSystems.length == 0 || chosenOperatingSystems.indexOf(os) >= 0) {
-                        createCompileApp(tmpDir, os, template.appType, template.path, pluginRepoUri, useSfdxRequested, sdkDependencies);
+                        createCompileApp(tmpDir, os, template.appType, template.path, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL);
                     }
                 }
             }
@@ -171,14 +173,14 @@ function main(args) {
             if (testingWithAppType) {
                 for (var j=0; j<chosenAppTypes.length; j++) {
                     var appType = chosenAppTypes[j];
-                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested, sdkDependencies);
+                    createCompileApp(tmpDir, os, appType, null, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL);
                 }
             }
 
             if (testingWithTemplate) {
                 // NB: chosenAppTypes[0] is appType from template
                 var appType = chosenAppTypes.length > 0 ? chosenAppTypes[0] : [templateHelper.getAppTypeFromTemplate(templateRepoUri)];
-                createCompileApp(tmpDir, os, appType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies);
+                createCompileApp(tmpDir, os, appType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL);
             }
         }
     }
@@ -201,6 +203,8 @@ function shortUsage(exitCode) {
     utils.logInfo('    [--spm-update]', COLOR.magenta);
     utils.logInfo('    [--spmrepouri=SPM_REPO_URI]', COLOR.magenta);
     utils.logInfo('    [--sdkdependencies=SDK_DEPDENDENCIES_OVERRIDE]', COLOR.magenta);
+    utils.logInfo('    [--consumerkey=OAUTH_CONSUMER_KEY]', COLOR.magenta);
+    utils.logInfo('    [--callbackurl=OAUTH_CALLBACK_URL]', COLOR.magenta);
     utils.logInfo('', COLOR.cyan);
     utils.logInfo('  Where:', COLOR.cyan);
     utils.logInfo('  - osX is : ios or android', COLOR.cyan);
@@ -208,6 +212,8 @@ function shortUsage(exitCode) {
     utils.logInfo('  - appTypeX is: ' + Object.values(APP_TYPE).join(' or '), COLOR.cyan);
     utils.logInfo('  - templaterepouri is a template repo uri or a Mobile SDK template name', COLOR.cyan);
     utils.logInfo('  - sdkdependencies is like {\"SalesforceMobileSDK-iOS\":\"https://github.com/somefork/SalesforceMobileSDK-iOS#somebranch\"}', COLOR.cyan);
+    utils.logInfo('  - consumerkey is the OAuth consumer key for the Salesforce External Client App or Connected App', COLOR.cyan);
+    utils.logInfo('  - callbackurl is the OAuth callback URL for the Salesforce External Client App or Connected App', COLOR.cyan);
     utils.logInfo('', COLOR.cyan);
 
     if (typeof(exitCode) !== 'undefined') {
@@ -299,7 +305,7 @@ function updatePluginRepo(tmpDir, os, pluginRepoDir, sdkBranch) {
 //
 // Create and compile app
 //
-function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies) {
+function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepoUri, useSfdxRequested, sdkDependencies, consumerKey, callbackURL) {
     var execArgs = '';
     var isNative = actualAppType == APP_TYPE.native || actualAppType == APP_TYPE.native_swift || actualAppType == APP_TYPE.native_kotlin; 
     var isReactNative = actualAppType == APP_TYPE.react_native || actualAppType == APP_TYPE.react_native_typescript;
@@ -356,6 +362,8 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
         + ' --packagename=' + packageName
         + ' --organization=Salesforce'
         + ' --outputdir=' + outputDir
+        + ' --consumerkey=' + consumerKey
+        + ' --callbackurl=' + callbackURL       
         + ' --verbose'
         + (isHybridRemote ? ' --startpage=' + defaultStartPage : '')
         + (isHybrid && pluginRepoUri ? ' --pluginrepouri=' + pluginRepoUri : '');


### PR DESCRIPTION
New optional args for the CLIs: consumer key, callback URL and login server.
- forceios/forcedroid/forcereact and forcehybrid and the sfdx-mobilesdk-plugin now support three new arguments
- test_force.js also optionally accepts a consumer key, callback URL and login server
- READMEs have been updated

These arguments are part of the config passed into the prepareTemplate call (**there will be a separate PR on the templates repo to make use of them**).

Also updated the details and next steps printed out during app generation.
- Details show the consumer key, callback url and login server if provided.
- Next steps indicate the need to provide such values (if they were not provided) before building/running the application.

**NB**: there are not needed to generate/build an application, however without valid values login will not be possible.