### PR TITLE
Skip prompting for platform and appType when only one option available

### DIFF
--- a/shared/configHelper.js
+++ b/shared/configHelper.js
@@ -47,7 +47,7 @@ function getArgsExpanded(cli, commandName) {
     var argNames = applyCli(SDK.commands[commandName].args, cli);
     return argNames
         .map(argName => SDK.args[argName])
-        .map(arg => 
+        .map(arg =>
             ({
                 name: arg.name,
                 'char': arg.char,
@@ -56,7 +56,7 @@ function getArgsExpanded(cli, commandName) {
                 prompt: applyCli(arg.prompt, cli),
                 error: applyCli(arg.error, cli),
                 validate: applyCli(arg.validate, cli),
-                promptIf: arg.promptIf,
+                promptIf: applyCli(arg.promptIf, cli),
                 required: arg.required === undefined ? true : arg.required,
                 hasValue: arg.hasValue === undefined ? true : arg.hasValue,
                 hidden: applyCli(arg.hidden, cli),

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -150,16 +150,18 @@ module.exports = {
             prompt: cli => 'Enter the target platform(s) separated by commas (' + cli.platforms.join(', ') + '):',
             error: cli => val => 'Platform(s) must be in ' + cli.platforms.join(', '),
             validate: cli => val => !val.split(",").some(p=>cli.platforms.indexOf(p) == -1),
+            promptIf: cli => otherArgs => cli.platforms.length > 1,
             type: 'string'
         },
         appType: {
             name:'apptype',
             'char':'t',
-            description: cli => 'application type (' + cli.appTypes.join(' or ') + ', leave empty for ' + cli.appTypes[0] + ')',
-            longDescription: cli => 'You can choose one of the following types of applications: ' + cli.appTypes.join(', ') + '.',
+            description: cli => cli.appTypes.length > 1 ? 'application type (' + cli.appTypes.join(' or ') + ', leave empty for ' + cli.appTypes[0] + ')' : '',
+            longDescription: cli => cli.appTypes.length > 1 ? 'You can choose one of the following types of applications: ' + cli.appTypes.join(', ') + '.' : '',
             prompt: cli => 'Enter your application type (' + cli.appTypes.join(' or ') + ', leave empty for ' + cli.appTypes[0] + '):',
             error: cli => val => 'App type must be ' + cli.appTypes.join(' or ') + '.',
             validate: cli => val => val === undefined || val === '' || cli.appTypes.indexOf(val) >=0,
+            promptIf: cli => otherArgs => cli.appTypes.length > 1,
             required: false,
             type: 'string'
         },
@@ -171,7 +173,7 @@ module.exports = {
             prompt: 'Enter URI of repo containing template application or a Mobile SDK template name:',
             error: cli => val => 'Invalid value for template repo uri: \'' + val + '\'.',
             validate: cli => val => /^\S+$/.test(val),
-            promptIf: otherArgs => !otherArgs.templatesource,
+            promptIf: cli => otherArgs => !otherArgs.templatesource,
             required: false,
             type: 'string'
         },
@@ -184,7 +186,7 @@ module.exports = {
             error: cli => val => 'Invalid value for template source: \'' + val + '\'.',
             validate: cli => val => /\S+/.test(val),
             // Process only when explicitly provided to avoid prompting during interactive flows
-            promptIf: otherArgs => typeof otherArgs.templatesource !== 'undefined',
+            promptIf: cli => otherArgs => typeof otherArgs.templatesource !== 'undefined',
             required: false,
             type: 'string'
         },
@@ -197,7 +199,7 @@ module.exports = {
             error: cli => val => 'Invalid value for template: \'' + val + '\'.',
             validate: cli => val => /\S+/.test(val),
             // Only prompt for template when a templatesource is provided
-            promptIf: otherArgs => !!otherArgs.templatesource,
+            promptIf: cli => otherArgs => !!otherArgs.templatesource,
             required: false,
             type: 'string'
         },
@@ -251,7 +253,7 @@ module.exports = {
             error: cli => val => 'Invalid value for start page: \'' + val + '\'.',
             validate: cli => val => /\S+/.test(val),
             required: false,
-            promptIf: otherArgs => otherArgs.apptype === 'hybrid_remote',
+            promptIf: cli => otherArgs => otherArgs.apptype === 'hybrid_remote',
             type: 'string'
         },
         configPath: {


### PR DESCRIPTION
## Summary

- Skip platform prompt when CLI has only one platform (e.g., forceios has only 'ios')
- Skip appType prompt when CLI has only one appType
- Hide appType description/longDescription when only one option available
- Standardize all `promptIf` functions to use consistent curried pattern

## Changes

### configHelper.js
- No changes to `applyCli()` function - it now handles all `promptIf` functions consistently
- `promptIf` is applied via `applyCli()` like all other function-valued arguments

### constants.js
- Added `promptIf: cli => otherArgs => cli.platforms.length > 1` to `platform` argument
- Added `promptIf: cli => otherArgs => cli.appTypes.length > 1` to `appType` argument
- Modified `description` and `longDescription` for `appType` to return empty string when only one option
- Updated all existing `promptIf` functions to use consistent curried pattern `cli => otherArgs => ...`
  - `templateRepoUri`, `templateSource`, `template`, `startPage` now all follow the same pattern
  - This ensures consistency even though some don't use the `cli` parameter

## Behavior

**Before**: Always prompted for platform/appType even with single option
**After**: Automatically uses the single option without prompting

## Examples

```bash
# forceios (only has 'ios' platform)
forceios create --appname=Test --packagename=com.test --organization=Test
# Previously: Prompted "Enter target platform: (ios):"
# Now: Skips platform prompt entirely

# If removing native templates leaves only native_swift
forceios create ...
# Will skip appType prompt automatically
```

## Testing

- Verified platform prompt skipped for forceios (single platform)
- Verified appType prompt still appears for forceios (has native, native_swift)
- Help text shows empty description when only one appType available
- All iOS native templates generate and build successfully via test_force.js

## Related

Supports the template removal workflow - when removing templates leaves a CLI with only one appType, prompting is automatically skipped with no additional code changes needed.