### PR TITLE
Add remove-template skill for Package repository

### DIFF
--- a/.claude/skills/remove-template.md
+++ b/.claude/skills/remove-template.md
@@ -100,7 +100,15 @@ cd sfdx
 ./generate_oclif.js
 ```
 
-#### 3.4. Generate SFDX Plugin README
+#### 3.4. Link SFDX Plugin
+
+Link the sfdx plugin to reflect the changes:
+
+```bash
+sf plugins link sfdx
+```
+
+#### 3.5. Generate SFDX Plugin README
 
 Update the SFDX plugin README with new help text:
 
@@ -158,6 +166,7 @@ grep -r "TemplateName" --include="*.js" --exclude-dir=node_modules .
   - [ ] appTypesToPath updated in constants.js
   - [ ] APP_TYPE enum updated in test_force.js
   - [ ] OCLIF commands regenerated: `sfdx/generate_oclif.js`
+  - [ ] SFDX plugin linked: `sf plugins link sfdx`
   - [ ] SFDX README regenerated: `sfdx/generate_readme.sh`
 - [ ] All JS files scanned: `grep -r "TemplateName" --include="*.js" --exclude-dir=node_modules .`
 - [ ] README.md updated

--- a/.claude/skills/remove-template.md
+++ b/.claude/skills/remove-template.md
@@ -1,0 +1,204 @@
+---
+name: remove-template
+description: Update Package repository after removing a template
+type: skill
+---
+
+# Update Package Repository After Template Removal
+
+This skill updates the SalesforceMobileSDK-Package repository after a template has been removed from the Templates repository.
+
+## Prerequisites
+
+- Template has been removed from Templates repo and pushed to a branch
+- Know the template's `appType` (from templates.json before removal)
+- Know if this was the **last template** with that `appType`
+
+## Steps
+
+### 1. Update setup_test_branches.js
+
+**File**: `release/setup_test_branches.js`
+
+**Lines 49-68**: Contains hardcoded array `templatesPackageJsons`.
+
+Remove the line for the deleted template:
+
+```javascript
+const templatesPackageJsons = [
+    './AndroidIDPTemplate/package.json',
+    './AndroidNativeKotlinTemplate/package.json',
+    // ... other templates ...
+    './TemplateName/package.json',  // ← REMOVE THIS LINE
+    './iOSNativeTemplate/package.json'
+]
+```
+
+### 2. Check constants.js for Default Template
+
+**File**: `shared/constants.js`
+
+**Check**: Is the removed template a **default** in `appTypesToPath`?
+
+```javascript
+forceclis: {
+    forceios: {
+        appTypesToPath: {
+            'native': 'iOSNativeTemplate',       // Check if removed template is here
+            'native_swift': 'iOSNativeSwiftTemplate'
+        }
+    }
+}
+```
+
+**Actions**:
+- If the removed template is a default AND another template exists with same appType:
+  - Replace with another template of the same appType
+- If the removed template is a default AND it's the last of that appType:
+  - Proceed to Step 3
+
+### 3. If Last Template of AppType - Remove AppType Support
+
+**Only if** the removed template was the **last template** with its `appType`:
+
+#### 3.1. Update constants.js
+
+Remove the appType from CLI definitions:
+
+```javascript
+forceclis: {
+    forcexxx: {
+        appTypes: ['native_swift', 'native'],  // ← Remove the appType
+        appTypesToPath: {
+            'native': 'iOSNativeTemplate',  // ← Remove mapping
+            'native_swift': 'iOSNativeSwiftTemplate'
+        }
+    }
+}
+```
+
+#### 3.2. Update test_force.js
+
+**File**: `test/test_force.js`
+
+Remove from `APP_TYPE` enum:
+
+```javascript
+var APP_TYPE = {
+    native: 'native',
+    native_swift: 'native_swift',  // ← Remove if last of this type
+    // ...
+};
+```
+
+#### 3.3. Generate OCLIF Command Classes
+
+After modifying constants.js, regenerate SFDX plugin commands:
+
+```bash
+cd sfdx
+./generate_oclif.js
+```
+
+#### 3.4. Generate SFDX Plugin README
+
+Update the SFDX plugin README with new help text:
+
+```bash
+cd sfdx
+./generate_readme.sh
+```
+
+### 4. Search All JS Files
+
+Search for any explicit references to the template name:
+
+```bash
+grep -r "TemplateName" --include="*.js" --exclude-dir=node_modules .
+```
+
+**Note**: These files work generically and should NOT have explicit references:
+- `release/release.js` - Generic template repo processing
+- `test/test_force.js` - Uses `templateHelper.getTemplates()` 
+- `shared/createHelper.js` - Generic template handling
+- `shared/templateHelper.js` - Dynamic template loading
+- `shared/configHelper.js` - Generic config handling
+
+**Action**: Only update if you find explicit references.
+
+### 5. Update README.md
+
+**File**: `README.md`
+
+**Search for**:
+- Template name in examples
+- AppType references (if appType was removed)
+
+**Remove**: Examples and documentation referencing the removed template/appType.
+
+### 6. Update CLAUDE.md
+
+**File**: `CLAUDE.md`
+
+**Search for**:
+- Template name in examples
+- AppType in documentation
+- AppType in CLI tool definitions
+
+**Remove**: All references to the removed template/appType.
+
+## Validation
+
+### Checklist
+
+- [ ] setup_test_branches.js updated (templatesPackageJsons array)
+- [ ] constants.js checked (updated if template was a default)
+- [ ] If last appType:
+  - [ ] appTypes array updated in constants.js
+  - [ ] appTypesToPath updated in constants.js
+  - [ ] APP_TYPE enum updated in test_force.js
+  - [ ] OCLIF commands regenerated: `sfdx/generate_oclif.js`
+  - [ ] SFDX README regenerated: `sfdx/generate_readme.sh`
+- [ ] All JS files scanned: `grep -r "TemplateName" --include="*.js" --exclude-dir=node_modules .`
+- [ ] README.md updated
+- [ ] CLAUDE.md updated
+
+### Test Prompting Behavior
+
+If you removed the last template of an appType, verify the prompt is automatically skipped:
+
+```bash
+# Test interactively - appType prompt should not appear for this CLI
+echo "" | node ios/forceios.js create --appname=TestApp --packagename=com.test.app --organization=Test
+```
+
+Expected: No prompt for appType if only one remains.
+
+### Run test_force.js
+
+**Important**: This requires pointing to the modified Templates repo branch.
+
+See the separate skill: `SalesforceMobileSDK-Workspace/.claude/skills/test-templates.md`
+
+## Commit Changes
+
+```bash
+git add -A
+git commit -m "Update Package repo after removing <TemplateName>
+
+Updated after template removal:
+- setup_test_branches.js: Removed from templatesPackageJsons array
+[- constants.js: Removed <appType> support (if last of type)]
+[- test_force.js: Removed APP_TYPE.<appType> (if last of type)]
+[- Regenerated OCLIF commands and SFDX README (if constants.js changed)]
+- README.md: Removed references
+- CLAUDE.md: Removed references"
+
+git push origin <branch-name>
+```
+
+## Next Steps
+
+After pushing, proceed to test both repos together using the test-templates skill.
+
+See: `SalesforceMobileSDK-Workspace/.claude/skills/test-templates.md`

--- a/.claude/skills/test-templates.md
+++ b/.claude/skills/test-templates.md
@@ -1,0 +1,238 @@
+---
+name: test-templates
+description: Test templates with test_force.js script
+type: skill
+---
+
+# Test Templates with test_force.js
+
+This skill documents testing templates in the Package repository using the `test/test_force.js` script.
+
+## Purpose
+
+After modifying CLI tools or templates, you need to verify that:
+1. CLI tools can generate apps from all applicable templates
+2. Generated apps install dependencies correctly
+3. Generated apps compile successfully
+
+## Prerequisites
+
+- Package repo with changes committed locally
+- npm dependencies installed (`npm install`)
+- Know which CLIs to test
+- Know which template source to test (if testing custom templates)
+
+## Basic Usage
+
+### Test All CLIs
+
+```bash
+./test/test_force.js --cli=forceios,forcedroid,forcehybrid,forcereact
+```
+
+### Test Specific CLI
+
+```bash
+./test/test_force.js --cli=forceios
+```
+
+### Test with SFDX Plugin
+
+```bash
+./test/test_force.js --cli=forceios --use-sfdx
+```
+
+### Exit on First Failure
+
+```bash
+./test/test_force.js --cli=forceios --exit-on-failure
+```
+
+## Testing with Custom Template Source
+
+When testing with templates from a specific branch:
+
+### Override Template Source
+
+```bash
+./test/test_force.js \
+  --cli=forceios \
+  --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates#my-feature
+```
+
+This makes the CLI use templates from the specified branch instead of the default.
+
+### Override SDK Dependencies
+
+```bash
+./test/test_force.js \
+  --cli=forceios \
+  --sdkdependencies='{"SalesforceMobileSDK-iOS":"https://github.com/wmathurin/SalesforceMobileSDK-iOS#my-feature"}'
+```
+
+This overrides SDK dependencies in template `package.json` files.
+
+### Combined: Templates and SDK
+
+```bash
+./test/test_force.js \
+  --cli=forceios \
+  --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates#template-changes \
+  --sdkdependencies='{"SalesforceMobileSDK-iOS":"https://github.com/wmathurin/SalesforceMobileSDK-iOS#sdk-changes"}'
+```
+
+## What Gets Tested
+
+For each applicable template, the script:
+
+1. **Packages CLI** - Creates .tgz package
+2. **Installs CLI** - Installs in temporary directory via npm
+3. **Generates App** - Runs CLI to generate app from template
+4. **Builds App** - Compiles generated app
+   - iOS: `xcodebuild` with workspace
+   - Android: `./gradlew assembleDebug`
+   - React Native: Both iOS and Android
+
+✅ **Tested**:
+- CLI tool packaging
+- App generation from templates
+- Dependency installation
+- Project compilation
+
+❌ **NOT Tested**:
+- Running the generated app
+- Unit tests
+- UI tests
+
+## Test Coverage by CLI
+
+| CLI | Templates Tested | Platforms |
+|-----|------------------|-----------|
+| **forceios** | All iOS native templates | iOS |
+| **forcedroid** | All Android native templates | Android |
+| **forcereact** | All React Native templates | iOS and Android |
+| **forcehybrid** | All hybrid templates | iOS and Android |
+
+## Common Testing Scenarios
+
+### After Modifying CLI Code
+
+Test all CLIs to ensure changes don't break app generation:
+
+```bash
+./test/test_force.js --cli=forceios,forcedroid,forcehybrid,forcereact
+```
+
+### After Removing a Template
+
+Test affected CLIs to ensure remaining templates work:
+
+```bash
+./test/test_force.js --cli=forceios
+```
+
+### Testing CLI with Custom Templates Branch
+
+When templates have been modified and pushed to a branch:
+
+```bash
+./test/test_force.js \
+  --cli=forceios \
+  --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates#remove-native
+```
+
+### Testing All CLIs with SPM Update
+
+```bash
+./test/test_force.js \
+  --cli=forceios,forcedroid,forcehybrid,forcereact \
+  --spm-update \
+  --spmrepouri=https://github.com/wmathurin/SalesforceMobileSDK-iOS-SPM#my-feature
+```
+
+## Output Interpretation
+
+**Success**:
+```
+!SUCCESS! GENERATING native_swift app for ios based on template iOSNativeSwiftTemplate (dev)
+!SUCCESS! COMPILING native_swift app for ios based on template iOSNativeSwiftTemplate (dev)
+```
+
+**Failure**:
+```
+!FAILURE! GENERATING native_swift app for ios based on template iOSNativeSwiftTemplate (dev)
+Command failed: ...
+```
+
+## Validation Checklist
+
+- [ ] Test script runs without errors
+- [ ] All applicable CLIs tested
+- [ ] All templates for each CLI generate successfully
+- [ ] All generated apps compile successfully
+- [ ] No dependency resolution errors
+
+## Integration with Other Skills
+
+This skill is used by:
+- **remove-template**: Test CLIs after template removal
+- **CLI modifications**: Test after changing CLI tool code
+- **Template changes**: Test CLI with modified templates
+
+## Example: Testing After Template Removal
+
+After removing templates from Templates repo and updating Package repo:
+
+```bash
+cd SalesforceMobileSDK-Package
+
+# Test affected CLI
+./test/test_force.js --cli=forceios --exit-on-failure
+```
+
+## Example: Cross-Repo Testing
+
+Testing Package repo changes with Templates repo changes:
+
+```bash
+cd SalesforceMobileSDK-Package
+
+# Test forceios with templates from branch
+./test/test_force.js \
+  --cli=forceios \
+  --templaterepouri=https://github.com/wmathurin/SalesforceMobileSDK-Templates#remove-native \
+  --exit-on-failure
+```
+
+## Notes
+
+- **test_force.js location**: Located in `test/` directory
+- **Temporary directory**: Creates `tmp<timestamp>/` for each test run
+- **Cleanup**: Removes temporary directory after successful tests
+- **Performance**: Testing all CLIs can take 45-90 minutes
+- **CI Integration**: Used by GitHub Actions workflows
+- **npm dependencies required**: Run `npm install` before testing
+
+## Alternative: Testing Without test_force.js
+
+You can also test by manually running CLI commands:
+
+```bash
+# Install CLI locally
+npm install -g .
+
+# Test with custom template source
+forceios createwithtemplate \
+  --templatesource=https://github.com/wmathurin/SalesforceMobileSDK-Templates#my-branch \
+  --template=iOSNativeSwiftTemplate \
+  --appname=TestApp \
+  --packagename=com.test.app \
+  --organization=Test \
+  --outputdir=/tmp/testapp
+```
+
+## Related Documentation
+
+- See `test/test_force.js` for full script implementation
+- See `.github/workflows/` for CI test configuration
+- See workspace skill `test-templates.md` for cross-repo testing coordination


### PR DESCRIPTION
## Summary

Add comprehensive skills for the Package repository:

1. **remove-template.md**: Process for updating Package repo after template removal
2. **test-templates.md**: Using test_force.js to test templates and CLI tools

## Skills Content

### remove-template.md

Documents the process for updating the Package repository after a template has been removed from the Templates repository:

- **setup_test_branches.js**: Update hardcoded templatesPackageJsons array
- **constants.js checks**: Handle default template mappings in appTypesToPath
- **AppType removal workflow** (if removing last template of an appType):
  - Remove appType from CLI definitions
  - Update test_force.js APP_TYPE enum
  - Regenerate OCLIF commands
  - Regenerate SFDX plugin README
- **Search for explicit references**: Grep all JS files for template name
- **Documentation updates**: README.md and CLAUDE.md

### test-templates.md

Documents using test_force.js to test templates and CLI tools:

- Testing with default or custom template sources
- Overriding template source branches via `--templaterepouri`
- Overriding SDK dependencies via `--sdkdependencies`
- Testing all CLIs or specific CLIs
- Cross-repo testing scenarios (templates + package changes)
- Performance notes and validation checklists

## Purpose

These skills are part of the coordinated template removal and testing workflow across the Mobile SDK ecosystem. They ensure that when templates are removed or modified, the Package repository (which contains CLI tools and release scripts) is properly updated and tested.

## Related Skills

- `SalesforceMobileSDK-Templates/.claude/skills/remove-template.md`
- `SalesforceMobileSDK-Templates/.claude/skills/test-template.md`
- `SalesforceMobileSDK-UITests/.claude/skills/remove-template.md`
- `SalesforceMobileSDK-Workspace/.claude/skills/remove-template.md` (orchestration)
- `SalesforceMobileSDK-Workspace/.claude/skills/test-templates.md` (orchestration)

## Note

This PR is based on `dev` branch. There are changes in the diff from PR #325 (automatic prompt skipping) that will be resolved via rebase after #325 is merged.