### PR TITLE
Update nightly schedule to Tue/Thu at 2 AM PT and fix security issues

### DIFF
--- a/.github/workflows/android-reusable-workflow.yaml
+++ b/.github/workflows/android-reusable-workflow.yaml
@@ -5,54 +5,73 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   forcedroid:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
           add-job-summary-as-pr-comment: on-failure
       - name: Build all android native templates
-        run: ./test/test_force.js --exit-on-failure --cli=forcedroid
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcedroid 2>&1 | tee "build_logs/forcedroid.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcedroid-sfdx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
@@ -60,28 +79,42 @@ jobs:
       - name: Install SFDX
         run: npm install -g @salesforce/cli
       - name: Build all android native templates wth SFDX
-        run: ./test/test_force.js --exit-on-failure --cli=forcedroid --use-sfdx 
-      
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcedroid --use-sfdx 2>&1 | tee "build_logs/forcedroid-sfdx.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
+
   forcehybrid-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
@@ -91,28 +124,42 @@ jobs:
       - name: Install Cordova
         run: npm install -g cordova
       - name: Build all android hybrid templates
-        run: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --no-plugin-update
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --no-plugin-update 2>&1 | tee "build_logs/forcehybrid-android.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcehybrid-android-sfdx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
@@ -122,28 +169,42 @@ jobs:
       - name: Install Cordova
         run: npm install -g cordova
       - name: Build all android hybrid templates with SFDX
-        run:  ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --use-sfdx --no-plugin-update
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=android --use-sfdx --no-plugin-update 2>&1 | tee "build_logs/forcehybrid-android-sfdx.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcereact-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
@@ -153,28 +214,42 @@ jobs:
       - name: Install Typescript
         run: npm install -g typescript
       - name: Build all android react native templates with SFDX
-        run: ./test/test_force.js --exit-on-failure --cli=forcereact --os=android
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcereact --os=android 2>&1 | tee "build_logs/forcereact-android.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcereact-android-sfdx:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: 'zulu'
           java-version: '21'
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-      - uses: gradle/actions/setup-gradle@v4
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407  # v3.2.2
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1  # v4.4.4
         with:
           gradle-version: "8.7"
           add-job-summary: on-failure
@@ -184,4 +259,16 @@ jobs:
       - name: Install Typescript
         run: npm install -g typescript
       - name: Build all android react native templates with SFDX
-        run: ./test/test_force.js --exit-on-failure --cli=forcereact --os=android --use-sfdx
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcereact --os=android --use-sfdx 2>&1 | tee "build_logs/forcereact-android-sfdx.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/ios-reusable-workflow.yaml
+++ b/.github/workflows/ios-reusable-workflow.yaml
@@ -9,51 +9,84 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   forceios:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
       - name: Build all ios native templates
-        run: ./test/test_force.js --exit-on-failure --cli=forceios
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forceios 2>&1 | tee "build_logs/forceios.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forceios-sfdx:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
       - name: Install SFDX
         run: npm install -g @salesforce/cli
       - name: Build all ios native templates with SFDX
-        run: ./test/test_force.js --exit-on-failure --cli=forceios --use-sfdx
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forceios --use-sfdx 2>&1 | tee "build_logs/forceios-sfdx.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcehybrid-ios:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
@@ -62,18 +95,32 @@ jobs:
       - name: Install Cordova
         run: npm install -g cordova
       - name: Build all ios hybrid templates
-        run: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --no-plugin-update
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --no-plugin-update 2>&1 | tee "build_logs/forcehybrid-ios.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcehybrid-ios-sfdx:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
@@ -82,36 +129,64 @@ jobs:
       - name: Install Cordova
         run: npm install -g cordova
       - name: Build all ios hybrid templates with SFDX
-        run: ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --use-sfdx --no-plugin-update
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcehybrid --os=ios --use-sfdx --no-plugin-update 2>&1 | tee "build_logs/forcehybrid-ios-sfdx.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcereact-ios:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
       - name: Install Typescript
         run: npm install -g typescript
       - name: Build all ios react native templates
-        run: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios 2>&1 | tee "build_logs/forcereact-ios.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14
 
   forcereact-ios-sfdx:
     runs-on: ${{ inputs.macos }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         if: ${{ ! inputs.is_pr }}
         with:
+          persist-credentials: false
           ref: ${{ github.head_ref }}
       - name: Install Dependencies
         run: npm install
@@ -120,4 +195,16 @@ jobs:
       - name: Install Typescript
         run: npm install -g typescript
       - name: Build all ios react native templates with SFDX
-        run: ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios --use-sfdx
+        id: build
+        run: |
+          mkdir -p build_logs
+          set -o pipefail
+          ./test/test_force.js --exit-on-failure --cli=forcereact --os=ios --use-sfdx 2>&1 | tee "build_logs/forcereact-ios-sfdx.log"
+      - name: Archive build logs on failure
+        if: failure() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: package-build-logs-${{ github.job }}
+          path: build_logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,17 +2,24 @@ name: Nightly Tests
 
 on:
   schedule:
-    - cron: "0 3 * * 3"  # cron is UTC, this translates to 8 PM PST Wednesday.
+    - cron: "0 10 * * 2,4"  # cron is UTC; 2 AM PT Tue/Thu.
   # This lets us trigger the workflow from a browser.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   android-nightly:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     uses: ./.github/workflows/android-reusable-workflow.yaml
-    
+
   ios-nightly:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ios-reusable-workflow.yaml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,8 +4,13 @@ on:
   pull_request:
     branches: [dev, master]
 
+permissions:
+  contents: read
+
 jobs:
   android-pr:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     uses: ./.github/workflows/android-reusable-workflow.yaml
@@ -13,6 +18,8 @@ jobs:
       is_pr: true
 
   ios-pr:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
     uses: ./.github/workflows/ios-reusable-workflow.yaml


### PR DESCRIPTION
## Summary

Implements [W-22712082 — Cleanup CI for all Repos](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b3viMYAQ/view).

**Schedule change**: Nightly tests now run **Tue/Thu at 2 AM PT** (`0 10 * * 2,4` UTC), up from Wed-only. Alternates with the Templates nightly's Mon/Wed/Fri 2 AM slot.

**Security hardening**: All workflows updated to follow the [GitHub Actions injection-prevention best practices](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):

- **All third-party actions SHA-pinned** with the resolved tag in a comment.
- **Top-level `permissions: contents: read`** added to every workflow, plus per-job `permissions:` on each `uses:` reusable caller (zizmor enforces both top-level and job-level checks).
- **Build logs archived on failure**: each of the 12 jobs in `ios-reusable-workflow.yaml` and `android-reusable-workflow.yaml` now `tee`s `test_force.js` output to `build_logs/<cli>.log` and uploads it as `package-build-logs-${{ github.job }}` on failure (with `if-no-files-found: ignore`, `retention-days: 14`).
- **`actions/checkout` steps** set `with: persist-credentials: false`.

This repo uses `pull_request` (not `pull_request_target`) and doesn't pass secrets to its reusables, so no `secrets: inherit` replacement was needed and no `dangerous-triggers` finding existed.

After this change, `zizmor --offline` reports 0 High-confidence findings across all four CI workflows.

## Test plan

- [x] Verified locally with `python3 yaml.safe_load`, `actionlint -shellcheck=`, `zizmor --offline`. All clean.
- [x] CI verification: opened test PR on personal fork (`brandonpage/SalesforceMobileSDK-Package#1`) targeting the same `cleanup-ci-w22712082` branch as this PR. The test PR triggers the new workflows against a real source change in `shared/outputColors.js`. **No regressions observed** — see linked PR for run details.
- [ ] Reviewer to confirm the `permissions:` blocks match the team's expected privilege levels for each workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
