### PR TITLE
Bump minimum Node.js requirement to 22

### DIFF
--- a/android/package.json
+++ b/android/package.json
@@ -10,7 +10,7 @@
     ],
     "bin" : { "forcedroid" : "forcedroid.js" },
     "engines": {
-        "node": ">=7.0.0"
+        "node": ">=22"
     },
     "dependencies": {
         "shelljs": "0.8.5",

--- a/ios/package.json
+++ b/ios/package.json
@@ -10,7 +10,7 @@
     ],
     "os" : [ "darwin" ],
     "engines": {
-        "node": ">=7.0.0"
+        "node": ">=22"
     },
     "bin" : { "forceios" : "forceios.js" },
     "dependencies": {

--- a/sfdx/package.json
+++ b/sfdx/package.json
@@ -21,7 +21,7 @@
         }
     ],
     "engines": {
-        "node": ">=8.10.0"
+        "node": ">=22"
     },
     "dependencies": {
         "@oclif/command": "^1.8.36",

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -40,7 +40,7 @@ module.exports = {
         },
         node: {
             checkCmd: 'node --version',
-            minVersion: '20'
+            minVersion: '22'
         },
         npm: {
             checkCmd: 'npm -v',


### PR DESCRIPTION
## Summary
- Update `shared/constants.js` `minVersion` for `node` from `20` to `22`
- Update `engines.node` in `ios/package.json` from `>=7.0.0` to `>=22`
- Update `engines.node` in `android/package.json` from `>=7.0.0` to `>=22`
- Update `engines.node` in `sfdx/package.json` from `>=8.10.0` to `>=22`

Node 22 is the current Active LTS release; this aligns all engine declarations with the runtime we actually require and test against.

GUS: W-22851866

## Test plan
- [ ] Run `npm test` (unit tests pass)
- [ ] Verify `forceios version` / `forcedroid version` still work on Node 22
- [ ] Verify `sf mobilesdk ios version` still works via the sfdx plugin on Node 22