### PR TITLE
W-21080629: Upgrade cordova-ios platform to 8.1.0; fix buildForiOS for new project structure

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -60,7 +60,7 @@ module.exports = {
         },
         cordova: {
             checkCmd: 'cordova -v',
-            pluginRepoUri: 'https://github.com/wmathurin/SalesforceMobileSDK-CordovaPlugin#W-21080629-cordova-ios-8',    // dev - REVERT BEFORE MERGING
+            pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#dev',    // dev
             minVersion: '13.0.0',
 //             pluginRepoUri: 'salesforce-mobilesdk-cordova-plugin@v' + VERSION, // GA
             platformVersion: {
@@ -79,7 +79,7 @@ module.exports = {
         android: 'Android Studio'
     },
 
-    templatesRepoUri: 'https://github.com/wmathurin/SalesforceMobileSDK-Templates#W-21080629-cordova-ios-8',    // dev - REVERT BEFORE MERGING
+    templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev',    // dev
 //     templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#v' + VERSION, // GA
 
     forceclis: {

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -64,7 +64,7 @@ module.exports = {
             minVersion: '13.0.0',
 //             pluginRepoUri: 'salesforce-mobilesdk-cordova-plugin@v' + VERSION, // GA
             platformVersion: {
-                ios: '7.1.1',
+                ios: '8.1.0',
                 android: '15.0.0'
             }
         },

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -79,7 +79,7 @@ module.exports = {
         android: 'Android Studio'
     },
 
-    templatesRepoUri: 'https://github.com/wmathurin/SalesforceMobileSDK-Templates#W-21080629-cordova-ios-8',    // dev (temporarily pointing to fork for testing)
+    templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev',    // dev
 //     templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#v' + VERSION, // GA
 
     forceclis: {

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -60,7 +60,7 @@ module.exports = {
         },
         cordova: {
             checkCmd: 'cordova -v',
-            pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#dev',    // dev
+            pluginRepoUri: 'https://github.com/wmathurin/SalesforceMobileSDK-CordovaPlugin#W-21080629-cordova-ios-8',    // dev - REVERT BEFORE MERGING
             minVersion: '13.0.0',
 //             pluginRepoUri: 'salesforce-mobilesdk-cordova-plugin@v' + VERSION, // GA
             platformVersion: {
@@ -79,7 +79,7 @@ module.exports = {
         android: 'Android Studio'
     },
 
-    templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev',    // dev
+    templatesRepoUri: 'https://github.com/wmathurin/SalesforceMobileSDK-Templates#W-21080629-cordova-ios-8',    // dev - REVERT BEFORE MERGING
 //     templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#v' + VERSION, // GA
 
     forceclis: {

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -79,7 +79,7 @@ module.exports = {
         android: 'Android Studio'
     },
 
-    templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev',    // dev
+    templatesRepoUri: 'https://github.com/wmathurin/SalesforceMobileSDK-Templates#W-21080629-cordova-ios-8',    // dev (temporarily pointing to fork for testing)
 //     templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#v' + VERSION, // GA
 
     forceclis: {

--- a/test/test_force.js
+++ b/test/test_force.js
@@ -407,11 +407,18 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
 
 function buildForiOS(target, workspaceDir, appName) {
     const workspacePath = path.join(workspaceDir, appName + '.xcworkspace');
+    // cordova-ios 8.x uses fixed 'App' name instead of app name
+    const appWorkspacePath = path.join(workspaceDir, 'App.xcworkspace');
     const projectPath = path.join(workspaceDir, appName + '.xcodeproj');
+    const appProjectPath = path.join(workspaceDir, 'App.xcodeproj');
     const buildTarget = existsSync(workspacePath)
           ? `-workspace ${workspacePath} -scheme ${appName}`
-          : `-project ${projectPath} -scheme ${appName}`;
-    
+          : existsSync(appWorkspacePath)
+          ? `-workspace ${appWorkspacePath} -scheme App`
+          : existsSync(projectPath)
+          ? `-project ${projectPath} -scheme ${appName}`
+          : `-project ${appProjectPath} -scheme App`;
+
     utils.runProcessCatchError(`xcodebuild ${buildTarget} clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -destination generic/platform=iOS`,
                                `COMPILING ${target}`);
 }


### PR DESCRIPTION
## Summary

- **`shared/constants.js`** — `platformVersion.ios: '7.1.1'` → `'8.1.0'`
- **`test/test_force.js`** — `buildForiOS` now handles cordova-ios 8.x's fixed project naming: `App.xcworkspace`/`App.xcodeproj` instead of `<appName>.xcworkspace`/`<appName>.xcodeproj`

## Test plan

- [ ] `forcehybrid create --os=ios` generates project with cordova-ios 8.1.0 — verified ✅
- [ ] `test_force.js --cli=forcehybrid --os=ios` succeeds for both hybrid_local and hybrid_remote — verified ✅

## ⚠️ Before Merging

The current tip of this branch temporarily points `pluginRepoUri` and `templatesRepoUri` in `shared/constants.js` to personal forks so CI can run against the feature branches. **These must be reverted to `forcedotcom` before merging:**

```javascript
// Revert pluginRepoUri to:
pluginRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-CordovaPlugin#dev',

// Revert templatesRepoUri to:
templatesRepoUri: 'https://github.com/forcedotcom/SalesforceMobileSDK-Templates#dev',
```

This revert should happen after the iOS-Hybrid, CordovaPlugin, and Templates PRs are merged to `dev`.