### PR TITLE
W-22970552: Skip PR CI for doc-only changes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,11 @@ name: Pull Request
 on:
   pull_request:
     branches: [dev, master]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'CODEOWNERS'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add `paths-ignore` to the PR workflow trigger so that pull requests touching only documentation files (`.md`, `LICENSE`, `.gitignore`, `CODEOWNERS`) skip CI entirely.

## Change

```yaml
paths-ignore:
  - '**/*.md'
  - 'LICENSE'
  - '.gitignore'
  - 'CODEOWNERS'
```

## Why

Running full build and test suites on doc-only PRs wastes CI resources with no benefit — documentation changes cannot affect build or test outcomes. Nightly workflows are intentionally unchanged.

## GUS

W-22970552

## Test plan

- [ ] Open a PR touching only a `.md` file — CI should not trigger
- [ ] Open a PR touching a source file + a `.md` file — CI should trigger normally