### PR TITLE
Parse --callbackurl into scheme/host/path for generated Android manifests (W-23294087)

### DIFF
--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -305,6 +305,26 @@ function hasValidOAuthConfig(config) {
 }
 
 //
+// Parse a callback URL into its scheme, host and path components.
+// Used to populate the Android redirect <intent-filter> in generated apps.
+// Node yields '' for the host of a hostless URI (e.g. testsfdc:///mobilesdk/detect/oauth/done);
+// that empty host is intentional and must NOT be coerced to '*'.
+// On parse failure returns null so the placeholders remain and the app still builds.
+//
+function parseCallbackUrl(callbackurl) {
+    try {
+        var url = new URL(callbackurl);
+        return {
+            scheme: url.protocol.replace(/:$/, ''),
+            host: url.host,
+            path: url.pathname
+        };
+    } catch (error) {
+        return null;
+    }
+}
+
+//
 // Print next steps
 //
 function printNextSteps(ide, projectPath, result, hasValidOAuth) {
@@ -489,7 +509,17 @@ function actuallyCreateApp(forcecli, config) {
 
         // Adding version
         config.version = SDK.version;
-        
+
+        // Parsing callback URL into scheme/host/path for the template (e.g. Android redirect intent-filter)
+        if (hasValidOAuthConfig(config)) {
+            var cb = parseCallbackUrl(config.callbackurl);
+            if (cb) {
+                config.callbackUrlScheme = cb.scheme;
+                config.callbackUrlHost = cb.host;
+                config.callbackUrlPath = cb.path;
+            }
+        }
+
         // Figuring out template repo uri and path
         let localTemplatesRoot;
         if (config.templatesource) {
@@ -623,5 +653,6 @@ function validateCustomProperties(templateJsonPath, customProperties) {
 
 module.exports = {
     createApp,
-    validateCustomProperties
+    validateCustomProperties,
+    parseCallbackUrl
 };

--- a/unittests/createHelper.test.js
+++ b/unittests/createHelper.test.js
@@ -185,4 +185,38 @@ describe('createHelper', () => {
             });
         });
     });
+
+    describe('parseCallbackUrl', () => {
+
+        it('should parse a hostless callback URL with an empty host', () => {
+            const result = createHelper.parseCallbackUrl('testsfdc:///mobilesdk/detect/oauth/done');
+
+            expect(result).toEqual({
+                scheme: 'testsfdc',
+                host: '',
+                path: '/mobilesdk/detect/oauth/done'
+            });
+            // Android has no host wildcard - an empty host must never become '*'
+            expect(result.host).not.toBe('*');
+        });
+
+        it('should parse a callback URL with a real host', () => {
+            const result = createHelper.parseCallbackUrl('sfdc://login.salesforce.com/oauth/done');
+
+            expect(result).toEqual({
+                scheme: 'sfdc',
+                host: 'login.salesforce.com',
+                path: '/oauth/done'
+            });
+            expect(result.host).not.toBe('*');
+        });
+
+        it('should treat the authority as the host', () => {
+            const result = createHelper.parseCallbackUrl('scheme://success/done');
+
+            expect(result.host).toBe('success');
+            expect(result.path).toBe('/done');
+            expect(result.host).not.toBe('*');
+        });
+    });
 });

--- a/unittests/createHelper.test.js
+++ b/unittests/createHelper.test.js
@@ -196,7 +196,8 @@ describe('createHelper', () => {
                 host: '',
                 path: '/mobilesdk/detect/oauth/done'
             });
-            // Android has no host wildcard - an empty host must never become '*'
+            // '*' IS an Android host wildcard (matches any host, over-broad); an empty
+            // host must mirror the empty authority as android:host="", never become '*'
             expect(result.host).not.toBe('*');
         });
 


### PR DESCRIPTION
## What

Parse the `--callbackurl` into its component parts so the generated **Android** app manifest can declare a redirect `<intent-filter>` that mirrors the callback URL. This is the packager half of enabling browser-based Advanced Authentication (default-ON in Mobile SDK 14.0) in generated apps.

## Changes

- **`shared/createHelper.js`**
  - Add and export `parseCallbackUrl(callbackurl) → {scheme, host, path}`, built on Node's `URL`. `host` is `url.host`, which is the **empty string** for a hostless callback (`scheme:///path`) — never `"*"`. `path` is `url.pathname`, which always carries a leading slash. Returns `null` on a parse failure so generation still succeeds (placeholders remain; the developer wires the redirect manually), matching the existing `hasValidOAuthConfig` behavior.
  - In `actuallyCreateApp`, right after `config.version = SDK.version;` and guarded on a valid OAuth config, set `config.callbackUrlScheme` / `config.callbackUrlHost` / `config.callbackUrlPath` from `parseCallbackUrl` — **before** the template's `prepare()` runs, so every `template.js` can substitute the manifest placeholders.
- **`unittests/createHelper.test.js`**: Jest coverage for `parseCallbackUrl` — hostless (`scheme:///path` → `host: ''`), host-bearing (`scheme://host/path`), and authority-as-host shapes; each asserts `host` is never `"*"`. 8/8 passing.

### Why `host` is `''` and never `"*"`

Android intent-filter matching is a conjunctive subset test: the incoming redirect URI must satisfy **every** `<data>` attribute the filter declares. A hostless callback has an empty authority, correctly mirrored by `android:host=""`. `"*"` is **not** a literal empty host — it **is** an Android host wildcard (matches any host), which would make the filter over-broad. So the parser emits `''`, and the template renders `android:host=""`.

## Dependency on the Templates PR (ship together)

This change only **populates** the parsed config fields; the manifest placeholders and the substitution/injection logic that consume `config.callbackUrl{Scheme,Host,Path}` live in the companion Templates PR:

**forcedotcom/SalesforceMobileSDK-Templates#543**

**These must land together.** They meet only at app-generation time: this PR sets the config fields, and the Templates `template.js` substitutes them into the manifest during `prepare()`. Without this PR, the Templates placeholders are never populated for CLI-generated apps; without Templates, these fields are set but unused. (In either half-applied state a generated app still builds — the redirect just isn't wired automatically.)

Note: the Templates repo's own CI does not depend on this PR — it builds raw templates without running the packager. This is a runtime/app-generation dependency, exercised by the CLI and by the UITests orchestrator E2E jobs.

## Testing

- `npm test` (Jest): `parseCallbackUrl` suite 8/8 pass.
- End-to-end through the real CLI path (this parser + the Templates `template.js` injection) verified via `forcehybrid createwithtemplate` for both hostless and host-bearing callbacks; the generated + built APK's binary manifest carries the correct scheme/host/path (`aapt2 dump xmltree`).

Work item: W-23294087