### PR TITLE
Add #GUSINFO to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
+#GUSINFO:Mobile SDK,Mobile SDK - Cross Platform
 #ECCN:Open Source


### PR DESCRIPTION
Adds the required `#GUSINFO:Mobile SDK,Mobile SDK - Cross Platform` line to CODEOWNERS to comply with FY27 OSPO code ownership requirements.