### PR TITLE
fix(release): remove stale libs/SalesforceReact/package.json from android filesWithOrg

### DIFF
--- a/release/setup_test_branches.js
+++ b/release/setup_test_branches.js
@@ -151,7 +151,7 @@ async function start() {
     }
 
     await prepareRepo(REPO.shared)
-    await prepareRepo(REPO.android, {hasDoc:true, filesWithOrg: ['.gitmodules', './libs/SalesforceReact/package.json'], submodulePaths:['./external/shared']})
+    await prepareRepo(REPO.android, {hasDoc:true, filesWithOrg: ['.gitmodules'], submodulePaths:['./external/shared']})
     await prepareRepo(REPO.ios, {hasDoc:true})
     await prepareRepo(REPO.ioshybrid, {filesWithOrg: ['.gitmodules'], submodulePaths:['./external/shared', './external/SalesforceMobileSDK-iOS']})
     await prepareRepo(REPO.iosspecs, {noTag: true, noDev: true, filesWithOrg:['update.sh']})


### PR DESCRIPTION
## Summary

- `SalesforceReact` was removed from the Android repo in SDK 14.0 — that file no longer exists at `libs/SalesforceReact/package.json`
- The stale entry in `filesWithOrg` would cause a `gsed` "no such file" error during test-branch setup for the Android repo
- The ReactNative repo is already processed separately via `prepareRepo(REPO.reactnative)` and handles its own org repointing

## Test plan

- [ ] Run `setup_test_branches.js` with a test org and confirm Android repo setup succeeds without "no such file" errors
- [ ] Verify `prepareRepo(REPO.reactnative)` correctly handles org repointing for the ReactNative repo

Fixes W-23916089