### PR TITLE
[Package] Default callback URL parts to empty string instead of undefined

### DIFF
--- a/shared/createHelper.js
+++ b/shared/createHelper.js
@@ -511,14 +511,12 @@ function actuallyCreateApp(forcecli, config) {
         config.version = SDK.version;
 
         // Parsing callback URL into scheme/host/path for the template (e.g. Android redirect intent-filter)
-        if (hasValidOAuthConfig(config)) {
-            var cb = parseCallbackUrl(config.callbackurl);
-            if (cb) {
-                config.callbackUrlScheme = cb.scheme;
-                config.callbackUrlHost = cb.host;
-                config.callbackUrlPath = cb.path;
-            }
-        }
+        // Defaulting to '' (rather than leaving undefined) so templates that substitute these
+        // unconditionally on a non-empty callbackurl don't inject the literal string "undefined".
+        var cb = hasValidOAuthConfig(config) ? parseCallbackUrl(config.callbackurl) : null;
+        config.callbackUrlScheme = cb ? cb.scheme : '';
+        config.callbackUrlHost = cb ? cb.host : '';
+        config.callbackUrlPath = cb ? cb.path : '';
 
         // Figuring out template repo uri and path
         let localTemplatesRoot;


### PR DESCRIPTION
## Summary

When OAuth config is invalid or `--callbackurl` fails to parse, `config.callbackUrlScheme/Host/Path`
were left `undefined` instead of set. Templates that unconditionally substitute these values (e.g.
into an Android manifest intent-filter) end up injecting the literal string `"undefined"` into
generated files instead of an empty value.

Fix: default all three to `''` when OAuth config is invalid or parsing fails, so downstream
template substitution always gets a defined (possibly empty) string.

## Test plan

- [x] Verified via `test_force.js` app-generation runs across native/hybrid/React Native templates
      during the 2026-08-21/22 dev-branch validation sweep — no regressions in callback URL handling
- [x] Confirmed generated files no longer contain the literal string `"undefined"` when OAuth config
      is omitted/invalid

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*