### PR TITLE
[Package] test_force.js --sdkdependencies flag is broken (double-JSON-encodes CLI arg)

### DIFF
--- a/test/test_force.js
+++ b/test/test_force.js
@@ -372,7 +372,7 @@ function createCompileApp(tmpDir, os, actualAppType, templateRepoUri, pluginRepo
         + (isHybrid && pluginRepoUri ? ' --pluginrepouri=' + pluginRepoUri : '');
 
     if (sdkDependencies) {
-        execArgs += ' --sdkDependencies=' + JSON.stringify(sdkDependencies).replace(/"/g, '\\"');
+        execArgs += ' --sdkDependencies=' + sdkDependencies.replace(/"/g, '\\"');
     }
 
     // Generation


### PR DESCRIPTION
## Summary

`test_force.js`'s `--sdkdependencies` value is already a JSON string (passed straight through
from the CLI arg). The code re-`JSON.stringify`'d it before forwarding to `forcereact`/`forceios`,
double-encoding the value and corrupting its quoting. `createHelper.js`'s `overrideSdkDependencies()`
then silently failed `JSON.parse()` on the corrupted string and no-op'd — so `--sdkdependencies`
has been non-functional for every caller of `test_force.js`, not just this repro.

Fix: pass the already-JSON-string value through as-is instead of re-stringifying it.

## Test plan

- [x] Re-ran `test_force.js` with `--sdkdependencies` pointed at a fork+branch override during the
      2026-08-22 integration re-test; generated app's `package.json` correctly reflected the
      override (previously silently ignored)
- [x] Confirmed `overrideSdkDependencies()` now successfully parses the passed-through value

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*